### PR TITLE
feat(transport): add stateless mode support for nostr client transport

### DIFF
--- a/.changeset/free-pans-hammer.md
+++ b/.changeset/free-pans-hammer.md
@@ -1,0 +1,5 @@
+---
+'@contextvm/sdk': patch
+---
+
+feat(transport): add stateless mode support for nostr client transport

--- a/src/__mocks__/mock-mcp-client-nostr-transport.ts
+++ b/src/__mocks__/mock-mcp-client-nostr-transport.ts
@@ -18,6 +18,7 @@ const transport = new NostrClientTransport({
   serverPubkey:
     'ada13b4dbc773890a5e8e468b72418b9fffb51c40b78236819a721971b14fed1',
   encryptionMode: EncryptionMode.DISABLED,
+  isStateless: true,
 });
 
 await client.connect(transport);
@@ -31,5 +32,3 @@ const callTool = await client.callTool({
   },
 });
 console.log(callTool);
-await sleep(1000);
-await client.ping();

--- a/src/__mocks__/mock-mcp-server-nostr-transport.ts
+++ b/src/__mocks__/mock-mcp-server-nostr-transport.ts
@@ -49,7 +49,6 @@ server.registerResource(
 const transport = new NostrServerTransport({
   signer: new PrivateKeySigner(TEST_PRIVATE_KEY),
   relayHandler: new ApplesauceRelayPool(['ws://localhost:10547']),
-  isPublicServer: true,
   serverInfo: {
     name: 'demo-server',
     website: 'https://model-context.org',

--- a/src/transport/nostr-client-transport.test.ts
+++ b/src/transport/nostr-client-transport.test.ts
@@ -1,0 +1,111 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  test,
+  expect,
+} from 'bun:test';
+import { sleep, type Subprocess } from 'bun';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { NostrServerTransport } from './nostr-server-transport.js';
+import { NostrClientTransport } from './nostr-client-transport.js';
+import { PrivateKeySigner } from '../signer/private-key-signer.js';
+import { generateSecretKey, getPublicKey, NostrEvent } from 'nostr-tools';
+import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
+import { ApplesauceRelayPool } from '../relay/applesauce-relay-pool.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { ListToolsResult } from '@modelcontextprotocol/sdk/types.js';
+import { EncryptionMode } from '../core/interfaces.js';
+
+const baseRelayPort = 7791;
+const relayUrl = `ws://localhost:${baseRelayPort}`;
+
+describe('NostrClientTransport', () => {
+  let relayProcess: Subprocess;
+  let server: McpServer;
+  let serverTransport: NostrServerTransport;
+  const serverPrivateKey = bytesToHex(generateSecretKey());
+  const serverPublicKey = getPublicKey(hexToBytes(serverPrivateKey));
+
+  beforeAll(async () => {
+    // Start mock relay
+    relayProcess = Bun.spawn(['bun', 'src/__mocks__/mock-relay.ts'], {
+      env: { ...process.env, PORT: `${baseRelayPort}` },
+      stdout: 'inherit',
+      stderr: 'inherit',
+    });
+    await sleep(200);
+
+    server = new McpServer({
+      name: 'Test-Server-For-Client-Test',
+      version: '1.0.0',
+    });
+
+    server.registerTool(
+      'add',
+      {
+        title: 'Addition Tool',
+        description: 'Add two numbers',
+        inputSchema: { a: z.number(), b: z.number() },
+      },
+      async ({ a, b }) => ({
+        content: [{ type: 'text', text: String(a + b) }],
+      }),
+    );
+
+    // Create and connect server transport
+    serverTransport = new NostrServerTransport({
+      signer: new PrivateKeySigner(serverPrivateKey),
+      relayHandler: new ApplesauceRelayPool([relayUrl]),
+    });
+    await server.connect(serverTransport);
+  });
+
+  afterEach(async () => {
+    // Clear relay cache
+    try {
+      const clearUrl = relayUrl.replace('ws://', 'http://') + '/clear-cache';
+      await fetch(clearUrl, { method: 'POST' });
+    } catch (error) {
+      console.warn('[TEST] Failed to clear event cache:', error);
+    }
+  });
+
+  afterAll(async () => {
+    await server.close();
+    relayProcess?.kill();
+    await sleep(100);
+  });
+
+  test('should connect and list tools in stateless mode', async () => {
+    // Create a client
+    const client = new Client({ name: 'Stateless-Client', version: '1.0.0' });
+    const clientPrivateKey = bytesToHex(generateSecretKey());
+
+    const clientTransport = new NostrClientTransport({
+      signer: new PrivateKeySigner(clientPrivateKey),
+      relayHandler: new ApplesauceRelayPool([relayUrl]),
+      serverPubkey: serverPublicKey,
+      isStateless: true, // Enable stateless mode
+      encryptionMode: EncryptionMode.DISABLED,
+    });
+
+    await client.connect(clientTransport);
+
+    const receivedEvents: NostrEvent[] = [];
+    clientTransport['relayHandler'].subscribe([{}], (event) => {
+      receivedEvents.push(event);
+    });
+
+    const tools: ListToolsResult = await client.listTools();
+    await sleep(100);
+    // Assertions
+    expect(tools).toBeDefined();
+    expect(Array.isArray(tools.tools)).toBe(true);
+    expect(tools.tools.length).toBe(1);
+    expect(receivedEvents.length).toBe(2);
+    await client.close();
+  }, 10000);
+});


### PR DESCRIPTION
This change introduces a stateless mode for the NostrClientTransport that allows clients to operate without requiring a full server initialization roundtrip. In stateless mode, the client emulates the server's initialize response, enabling faster startup and reduced network overhead.

The stateless mode is controlled by the `isStateless` option in the transport configuration. When enabled, the client will:
- Emulate the initialize response without sending it over the network
- Skip sending and handling of `notifications/initialized` messages

resolves: #11 