### PR TITLE
test: bind mock relay to IPv4 loopback to fix localhost timeouts

### DIFF
--- a/src/__mocks__/mock-relay-server.ts
+++ b/src/__mocks__/mock-relay-server.ts
@@ -211,6 +211,7 @@ export function startMockRelay(
   }
 
   const server = serve({
+    hostname: '127.0.0.1',
     port: options.port ?? 0,
     fetch(req, server) {
       const url = new URL(req.url);
@@ -294,8 +295,8 @@ export function startMockRelay(
   return {
     server,
     port,
-    relayUrl: `ws://localhost:${port}`,
-    httpUrl: `http://localhost:${port}`,
+    relayUrl: `ws://127.0.0.1:${port}`,
+    httpUrl: `http://127.0.0.1:${port}`,
     stop: () => {
       // Close any existing WebSocket connections before stopping the server.
       for (const instance of state.connections.values()) {


### PR DESCRIPTION
**What does this PR do?**
Explicitly binds the internal `mock-relay-server` to the `127.0.0.1` IPv4 loopback address rather than relying on default `localhost` resolution. 

**Why is this necessary?**
Currently, tests such as `NostrServerTransport` fail and time out for some when running locally. This occurs because some operating systems default to resolving the `localhost` DNS query to the IPv6 loopback address (`::1`) first. 

Since the `Bun.serve` engine used in the mock server binds to `0.0.0.0` (all IPv4 interfaces) by default, but the returned URL explicitly instructs the client transport to connect to `ws://localhost:<port>`, the test connection hangs while waiting for an IPv6 server that doesn't exist, eventually timing out.

**How does this fix the issue?**
- Explicitly passes `hostname: '127.0.0.1'` to the `serve` engine to guarantee IPv4 listening.
- Modifies `relayUrl` and `httpUrl` to return `127.0.0.1` instead of `localhost` so the fetch and WebSocket clients predictably hit the bound IPv4 server rather than `::1`

**Checklist:**
- [x] Ran `bun run format` and `bun run lint` successfully.
- [x] Ran `bun test` locally (all tests pass 209/209 without timeouts).
- [x] Verified build output via `bun run build`.