### PR TITLE
test: await async expect assertions in transport tests

### DIFF
--- a/src/transport/nostr-transport-encryption.test.ts
+++ b/src/transport/nostr-transport-encryption.test.ts
@@ -106,7 +106,9 @@ describe.serial('NostrTransport Encryption', () => {
         EncryptionMode.OPTIONAL,
       );
 
-      expect(client.connect(clientNostrTransport)).resolves.toBeUndefined();
+      await expect(
+        client.connect(clientNostrTransport),
+      ).resolves.toBeUndefined();
 
       await client.close();
       await server.close();

--- a/src/transport/payments-flow.test.ts
+++ b/src/transport/payments-flow.test.ts
@@ -749,7 +749,7 @@ describe.serial('payments fake flow (transport-level)', () => {
       forwarded += 1;
     };
 
-    expect(mw(message, ctx, forward)).rejects.toThrow(/create failed/);
+    await expect(mw(message, ctx, forward)).rejects.toThrow(/create failed/);
     expect(forwarded).toBe(0);
   });
 


### PR DESCRIPTION
This PR fixes missing await usage on async Jest-style assertions in transport tests.
Without await, the test can complete before the resolves/rejects assertion is actually evaluated, which can hide failures and add timing-related flakiness.

**Changes**
- Added await to a resolves assertion in [`nostr-transport-encryption.test.ts:109`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Added await to a rejects assertion in [`payments-flow.test.ts:752`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Aim behind the PR**
- Ensures async assertions are actually executed before test completion
- Prevents false positives where tests appear green even if the promise assertion fails
- Reduces race conditions with teardown in async transport tests

**Validation**
- Targeted tests:
  - bun test [`nostr-transport-encryption.test.ts`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) [`payments-flow.test.ts`](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
  - Result: 22 pass, 0 fail
- Full suite:
  - bun run test
  - Result: 209 pass, 5 skip, 0 fail

**Related issue**
Closes #33 