### PR TITLE
feat(transport): add oversized transfer framing

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -105,6 +105,11 @@ export const NOSTR_TAGS = {
    * Support ephemeral gift wrap kind (21059) for encrypted messages.
    */
   SUPPORT_ENCRYPTION_EPHEMERAL: 'support_encryption_ephemeral',
+
+  /**
+   * Support framed oversized transfer over notifications/progress.
+   */
+  SUPPORT_OVERSIZED_TRANSFER: 'support_oversized_transfer',
 } as const;
 
 export const DEFAULT_LRU_SIZE = 5000;

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -2,3 +2,4 @@ export * from './nostr-client-transport.js';
 export * from './nostr-server-transport.js';
 export * from './nostr-server/announcement-manager.js';
 export * from './base-nostr-transport.js';
+export * from './oversized-transfer/index.js';

--- a/src/transport/nostr-client-transport.ts
+++ b/src/transport/nostr-client-transport.ts
@@ -47,6 +47,15 @@ import {
 import { StatelessModeHandler } from './nostr-client/stateless-mode-handler.js';
 import { withTimeout } from '../core/utils/utils.js';
 import { ApplesauceRelayPool } from '../relay/applesauce-relay-pool.js';
+import {
+  DEFAULT_CHUNK_SIZE_BYTES,
+  DEFAULT_OVERSIZED_THRESHOLD_BYTES,
+  OversizedTransferReceiver,
+  buildOversizedTransferFrames,
+  type TransferPolicy,
+  type OversizedTransferProgressParams,
+  utf8ByteLength,
+} from './oversized-transfer/index.js';
 
 function hasSingleTag(tags: string[][], tag: string): boolean {
   return tags.some((t) => t.length === 1 && t[0] === tag);
@@ -70,6 +79,7 @@ function hasKnownDiscoveryTag(event: NostrEvent | undefined): boolean {
     NOSTR_TAGS.PICTURE,
     NOSTR_TAGS.SUPPORT_ENCRYPTION,
     NOSTR_TAGS.SUPPORT_ENCRYPTION_EPHEMERAL,
+    NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER,
   ]);
 
   return event.tags.some((tag) => knownDiscoveryTags.has(tag[0] ?? ''));
@@ -103,6 +113,19 @@ export interface NostrTransportOptions extends Omit<
   isStateless?: boolean;
   /** Log level for the transport */
   logLevel?: LogLevel;
+  /** Options controlling framed oversized transfer behavior. */
+  oversizedTransfer?: {
+    /** Whether oversized transfer handling is enabled. @default true */
+    enabled?: boolean;
+    /** Byte threshold for proactive request fragmentation. @default 48000 */
+    thresholdBytes?: number;
+    /** Per-chunk UTF-8 byte limit. @default 24000 */
+    chunkSizeBytes?: number;
+    /** Timeout while waiting for `accept` when handshake is required. */
+    acceptTimeoutMs?: number;
+    /** Receiver-side policy limits for inbound oversized frames. */
+    policy?: TransferPolicy;
+  };
 }
 
 /**
@@ -155,6 +178,14 @@ export class NostrClientTransport
 
   /** Whether the server has advertised ephemeral gift wrap support via Nostr tags. */
   private serverSupportsEphemeralGiftWraps: boolean = false;
+  /** Whether the server has advertised framed oversized-transfer support. */
+  private serverSupportsOversizedTransfer: boolean = false;
+
+  private readonly oversizedEnabled: boolean;
+  private readonly oversizedThreshold: number;
+  private readonly oversizedChunkSize: number;
+  private readonly oversizedAcceptTimeoutMs: number;
+  private readonly oversizedReceiver: OversizedTransferReceiver;
 
   /**
    * Deduplicate inbound events to avoid redundant work.
@@ -190,6 +221,19 @@ export class NostrClientTransport
       },
     });
     this.statelessHandler = new StatelessModeHandler();
+
+    const oversizedOptions = options.oversizedTransfer;
+    this.oversizedEnabled = oversizedOptions?.enabled ?? true;
+    this.oversizedThreshold =
+      oversizedOptions?.thresholdBytes ?? DEFAULT_OVERSIZED_THRESHOLD_BYTES;
+    this.oversizedChunkSize =
+      oversizedOptions?.chunkSizeBytes ?? DEFAULT_CHUNK_SIZE_BYTES;
+    this.oversizedAcceptTimeoutMs =
+      oversizedOptions?.acceptTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.oversizedReceiver = new OversizedTransferReceiver(
+      oversizedOptions?.policy,
+      this.logger,
+    );
   }
 
   /**
@@ -246,6 +290,7 @@ export class NostrClientTransport
       await this.disconnect();
       this.correlationStore.clear();
       this.seenEventIds.clear();
+      this.oversizedReceiver.clear();
       this.onclose?.();
     } catch (error) {
       this.onerror?.(error instanceof Error ? error : new Error(String(error)));
@@ -297,12 +342,34 @@ export class NostrClientTransport
   private async sendRequest(message: JSONRPCMessage): Promise<string> {
     const isRequest = isJSONRPCRequest(message);
 
+    if (this.oversizedEnabled && isRequest) {
+      const progressToken = message.params?._meta?.progressToken;
+      if (progressToken !== undefined) {
+        const serialized = JSON.stringify(message);
+        if (utf8ByteLength(serialized) > this.oversizedThreshold) {
+          return await this.sendOversizedRequest(
+            message,
+            serialized,
+            String(progressToken),
+          );
+        }
+      }
+    }
+
     const pmiTags: string[][] =
       isRequest && this.clientPmis
         ? this.clientPmis.map((pmi) => ['pmi', pmi] as string[])
         : [];
 
-    const tags = [...this.createRecipientTags(this.serverPubkey), ...pmiTags];
+    const oversizedTags = this.oversizedEnabled
+      ? [[NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER]]
+      : [];
+
+    const tags = [
+      ...this.createRecipientTags(this.serverPubkey),
+      ...pmiTags,
+      ...oversizedTags,
+    ];
 
     const giftWrapKind = this.chooseOutboundGiftWrapKind();
 
@@ -329,6 +396,102 @@ export class NostrClientTransport
       },
       giftWrapKind,
     );
+  }
+
+  private async sendOversizedRequest(
+    originalMessage: JSONRPCMessage,
+    serializedMessage: string,
+    progressToken: string,
+  ): Promise<string> {
+    const pmiTags: string[][] = this.clientPmis
+      ? this.clientPmis.map((pmi) => ['pmi', pmi] as string[])
+      : [];
+
+    const baseTags = [
+      ...this.createRecipientTags(this.serverPubkey),
+      ...pmiTags,
+      [NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER],
+    ];
+
+    const giftWrapKind = this.chooseOutboundGiftWrapKind();
+    const needsAcceptHandshake = !this.serverSupportsOversizedTransfer;
+
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      serializedMessage,
+      {
+        progressToken,
+        chunkSizeBytes: this.oversizedChunkSize,
+        needsAcceptHandshake,
+      },
+    );
+
+    const sendFrame = async (
+      params: OversizedTransferProgressParams,
+      onEventCreated?: (eventId: string) => void,
+    ): Promise<string> => {
+      const notification: JSONRPCMessage = {
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params,
+      };
+
+      return await this.sendMcpMessage(
+        notification,
+        this.serverPubkey,
+        CTXVM_MESSAGES_KIND,
+        baseTags,
+        undefined,
+        onEventCreated,
+        giftWrapKind,
+      );
+    };
+
+    await sendFrame(startFrame);
+
+    if (needsAcceptHandshake) {
+      try {
+        await this.oversizedReceiver.waitForAccept(
+          progressToken,
+          this.oversizedAcceptTimeoutMs,
+        );
+      } catch (error) {
+        const reason =
+          error instanceof Error
+            ? error.message
+            : 'Timed out waiting for oversized accept';
+        const abortProgress = startFrame.progress + 1;
+
+        await sendFrame({
+          progressToken,
+          progress: abortProgress,
+          message: 'oversized transfer aborted',
+          cvm: {
+            type: 'oversized-transfer',
+            frameType: 'abort',
+            reason,
+          },
+        }).catch(() => undefined);
+
+        throw error;
+      }
+    }
+
+    for (const chunkFrame of chunkFrames) {
+      await sendFrame(chunkFrame);
+    }
+
+    return await sendFrame(endFrame, (eventId) => {
+      if (!isJSONRPCRequest(originalMessage)) {
+        return;
+      }
+
+      this.correlationStore.registerRequest(eventId, {
+        originalRequestId: originalMessage.id,
+        isInitialize: originalMessage.method === INITIALIZE_METHOD,
+        progressToken,
+        originalRequestContext: this.getOriginalRequestContext(originalMessage),
+      });
+    });
   }
 
   private chooseOutboundGiftWrapKind(): number {
@@ -501,6 +664,17 @@ export class NostrClientTransport
         this.serverSupportsEphemeralGiftWraps = true;
       }
 
+      if (
+        !this.serverSupportsOversizedTransfer &&
+        Array.isArray(nostrEvent.tags) &&
+        hasSingleTag(
+          nostrEvent.tags as string[][],
+          NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER,
+        )
+      ) {
+        this.serverSupportsOversizedTransfer = true;
+      }
+
       const eTag = getNostrEventTag(nostrEvent.tags, 'e');
 
       if (!this.serverInitializeEvent && hasKnownDiscoveryTag(nostrEvent)) {
@@ -586,6 +760,15 @@ export class NostrClientTransport
       }
 
       if (isJSONRPCNotification(mcpMessage)) {
+        if (OversizedTransferReceiver.isOversizedFrame(mcpMessage)) {
+          this.handleOversizedNotification(
+            nostrEvent.id,
+            eTag ?? undefined,
+            mcpMessage,
+          );
+          return;
+        }
+
         this.handleNotification(nostrEvent.id, eTag ?? undefined, mcpMessage);
         return;
       }
@@ -892,6 +1075,47 @@ export class NostrClientTransport
     }
   }
 
+  private handleOversizedNotification(
+    eventId: string,
+    correlatedEventId: string | undefined,
+    notification: JSONRPCMessage,
+  ): void {
+    if (!isJSONRPCNotification(notification)) {
+      return;
+    }
+
+    try {
+      this.serverSupportsOversizedTransfer = true;
+      const synthetic = this.oversizedReceiver.processFrame(notification);
+      if (!synthetic) {
+        return;
+      }
+
+      if (isJSONRPCResultResponse(synthetic) || isJSONRPCErrorResponse(synthetic)) {
+        if (correlatedEventId) {
+          this.handleResponse(correlatedEventId, synthetic);
+          return;
+        }
+        this.onmessage?.(synthetic);
+        return;
+      }
+
+      if (isJSONRPCNotification(synthetic)) {
+        this.handleNotification(eventId, correlatedEventId, synthetic);
+        return;
+      }
+
+      this.onmessage?.(synthetic);
+    } catch (error) {
+      this.logger.error('Error handling oversized transfer frame', {
+        error: error instanceof Error ? error.message : String(error),
+        eventId,
+        correlatedEventId,
+      });
+      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
   /**
    * Test-only accessor for internal state.
    * @internal
@@ -909,6 +1133,7 @@ export class NostrClientTransport
       serverResourcesListEvent: this.serverResourcesListEvent,
       serverResourceTemplatesListEvent: this.serverResourceTemplatesListEvent,
       serverPromptsListEvent: this.serverPromptsListEvent,
+      serverSupportsOversizedTransfer: this.serverSupportsOversizedTransfer,
     };
   }
 }

--- a/src/transport/nostr-server-transport.ts
+++ b/src/transport/nostr-server-transport.ts
@@ -45,6 +45,19 @@ import {
   ServerInfo,
 } from './nostr-server/announcement-manager.js';
 import type { RelayHandler } from '../core/interfaces.js';
+import {
+  DEFAULT_CHUNK_SIZE_BYTES,
+  DEFAULT_OVERSIZED_THRESHOLD_BYTES,
+  OversizedTransferReceiver,
+  buildOversizedTransferFrames,
+  type OversizedTransferProgressParams,
+  type TransferPolicy,
+  utf8ByteLength,
+} from './oversized-transfer/index.js';
+
+function hasSingleTag(tags: string[][], tag: string): boolean {
+  return tags.some((t) => t.length === 1 && t[0] === tag);
+}
 
 /**
  * Options for configuring the NostrServerTransport.
@@ -105,6 +118,18 @@ export interface NostrServerTransportOptions extends BaseNostrTransportOptions {
     ctx: { clientPubkey: string },
     forward: (message: JSONRPCMessage) => Promise<void>,
   ) => Promise<void>;
+
+  /** Options controlling framed oversized transfer behavior. */
+  oversizedTransfer?: {
+    /** Whether oversized transfer handling is enabled. @default true */
+    enabled?: boolean;
+    /** Byte threshold for proactive response fragmentation. @default 48000 */
+    thresholdBytes?: number;
+    /** Per-chunk UTF-8 byte limit. @default 24000 */
+    chunkSizeBytes?: number;
+    /** Receiver-side policy limits for inbound oversized frames. */
+    policy?: TransferPolicy;
+  };
 }
 
 export type InboundMiddlewareFn = (
@@ -143,6 +168,10 @@ export class NostrServerTransport
       }) => void | Promise<void>)
     | undefined;
   private readonly inboundMiddlewares: InboundMiddlewareFn[] = [];
+  private readonly oversizedReceiver: OversizedTransferReceiver;
+  private readonly oversizedEnabled: boolean;
+  private readonly oversizedThreshold: number;
+  private readonly oversizedChunkSize: number;
 
   /**
    * Deduplicate inbound events to avoid redundant work.
@@ -187,10 +216,13 @@ export class NostrServerTransport
           this.logger.debug(
             `Recreating session ${clientPubkey} due to active routes`,
           );
-          this.sessionStore.getOrCreateSession(
+          const [recreatedSession] = this.sessionStore.getOrCreateSession(
             clientPubkey,
             session.isEncrypted,
           );
+          recreatedSession.hasSentCommonTags = session.hasSentCommonTags;
+          recreatedSession.supportsOversizedTransfer =
+            session.supportsOversizedTransfer;
           return; // Don't call onClientSessionEvicted for vetoed eviction
         }
 
@@ -239,6 +271,23 @@ export class NostrServerTransport
         this.relayHandler.subscribe(filters, onEvent).then(() => undefined),
       logger: this.logger,
     });
+
+    const oversizedOptions = options.oversizedTransfer;
+    this.oversizedEnabled = oversizedOptions?.enabled ?? true;
+    this.oversizedThreshold =
+      oversizedOptions?.thresholdBytes ?? DEFAULT_OVERSIZED_THRESHOLD_BYTES;
+    this.oversizedChunkSize =
+      oversizedOptions?.chunkSizeBytes ?? DEFAULT_CHUNK_SIZE_BYTES;
+    this.oversizedReceiver = new OversizedTransferReceiver(
+      oversizedOptions?.policy,
+      this.logger,
+    );
+
+    if (this.oversizedEnabled) {
+      this.announcementManager.setExtraCommonTags([
+        [NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER],
+      ]);
+    }
   }
 
   /**
@@ -247,7 +296,16 @@ export class NostrServerTransport
    * Intended for optional protocol extensions (e.g. CEP-8 PMI discovery).
    */
   public setAnnouncementExtraTags(tags: string[][]): void {
-    this.announcementManager.setExtraCommonTags(tags);
+    const nextTags = [...tags];
+
+    if (
+      this.oversizedEnabled &&
+      !hasSingleTag(nextTags, NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER)
+    ) {
+      nextTags.push([NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER]);
+    }
+
+    this.announcementManager.setExtraCommonTags(nextTags);
   }
 
   /**
@@ -323,6 +381,7 @@ export class NostrServerTransport
       this.sessionStore.clear();
       this.correlationStore.clear();
       this.seenEventIds.clear();
+      this.oversizedReceiver.clear();
       this.onclose?.();
     } catch (error) {
       this.onerror?.(error instanceof Error ? error : new Error(String(error)));
@@ -555,6 +614,25 @@ export class NostrServerTransport
       }
     }
 
+    if (
+      this.oversizedEnabled &&
+      route.progressToken &&
+      session.supportsOversizedTransfer
+    ) {
+      const serializedResponse = JSON.stringify(response);
+      if (utf8ByteLength(serializedResponse) > this.oversizedThreshold) {
+        await this.sendOversizedResponse({
+          serializedResponse,
+          clientPubkey: route.clientPubkey,
+          progressToken: route.progressToken,
+          tags,
+          isEncrypted: session.isEncrypted,
+          giftWrapKind,
+        });
+        return;
+      }
+    }
+
     await this.sendMcpMessage(
       response,
       route.clientPubkey,
@@ -563,6 +641,79 @@ export class NostrServerTransport
       session.isEncrypted,
       undefined,
       giftWrapKind,
+    );
+  }
+
+  private async sendOversizedResponse(options: {
+    serializedResponse: string;
+    clientPubkey: string;
+    progressToken: string;
+    tags: string[][];
+    isEncrypted: boolean;
+    giftWrapKind: number | undefined;
+  }): Promise<void> {
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      options.serializedResponse,
+      {
+        progressToken: options.progressToken,
+        chunkSizeBytes: this.oversizedChunkSize,
+        needsAcceptHandshake: false,
+      },
+    );
+
+    const sendFrame = async (
+      params: OversizedTransferProgressParams,
+    ): Promise<void> => {
+      const notification: JSONRPCMessage = {
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params,
+      };
+
+      await this.sendMcpMessage(
+        notification,
+        options.clientPubkey,
+        CTXVM_MESSAGES_KIND,
+        options.tags,
+        options.isEncrypted,
+        undefined,
+        options.giftWrapKind,
+      );
+    };
+
+    await sendFrame(startFrame);
+    for (const chunkFrame of chunkFrames) {
+      await sendFrame(chunkFrame);
+    }
+    await sendFrame(endFrame);
+  }
+
+  private async sendAcceptFrame(options: {
+    clientPubkey: string;
+    progressToken: string;
+    progress: number;
+    correlatedEventId: string;
+  }): Promise<void> {
+    const acceptParams: OversizedTransferProgressParams = {
+      progressToken: options.progressToken,
+      progress: options.progress,
+      message: 'oversized transfer accepted',
+      cvm: {
+        type: 'oversized-transfer',
+        frameType: 'accept',
+      },
+    };
+
+    const notification: JSONRPCMessage = {
+      jsonrpc: '2.0',
+      method: 'notifications/progress',
+      params: acceptParams,
+    };
+
+    await this.sendNotification(
+      options.clientPubkey,
+      notification,
+      options.correlatedEventId,
     );
   }
 
@@ -848,23 +999,17 @@ export class NostrServerTransport
       }
 
       // Get or create session for this client (ensures session exists for authorized messages)
-      this.getOrCreateClientSession(event.pubkey, isEncrypted);
+      const session = this.getOrCreateClientSession(event.pubkey, isEncrypted);
 
-      // Handle message routing and conditionally inject client pubkey
-      if (isJSONRPCRequest(mcpMessage)) {
-        this.handleIncomingRequest(
-          event.id,
-          mcpMessage,
-          event.pubkey,
-          wrapKind,
-        );
-
-        // Inject client public key for enhanced server integration (in-place mutation)
-        if (this.injectClientPubkey) {
-          injectClientPubkey(mcpMessage, event.pubkey);
-        }
-      } else if (isJSONRPCNotification(mcpMessage)) {
-        this.handleIncomingNotification(event.pubkey, mcpMessage);
+      if (
+        this.oversizedEnabled &&
+        Array.isArray(event.tags) &&
+        hasSingleTag(
+          event.tags as string[][],
+          NOSTR_TAGS.SUPPORT_OVERSIZED_TRANSFER,
+        )
+      ) {
+        session.supportsOversizedTransfer = true;
       }
 
       const forward = async (msg: JSONRPCMessage): Promise<void> => {
@@ -897,7 +1042,79 @@ export class NostrServerTransport
         });
       };
 
-      void dispatch(0, mcpMessage).catch((err: unknown) => {
+      let dispatchMessage: JSONRPCMessage | null = mcpMessage;
+
+      // Handle message routing and conditionally inject client pubkey.
+      if (isJSONRPCRequest(mcpMessage)) {
+        this.handleIncomingRequest(
+          event.id,
+          mcpMessage,
+          event.pubkey,
+          wrapKind,
+        );
+
+        if (this.injectClientPubkey) {
+          injectClientPubkey(mcpMessage, event.pubkey);
+        }
+      } else if (isJSONRPCNotification(mcpMessage)) {
+        if (
+          this.oversizedEnabled &&
+          OversizedTransferReceiver.isOversizedFrame(mcpMessage)
+        ) {
+          const synthetic = this.oversizedReceiver.processFrame(mcpMessage);
+          const frameType =
+            (mcpMessage.params?.cvm as { frameType?: string } | undefined)
+              ?.frameType ?? '';
+
+          if (frameType === 'start') {
+            const progressToken = mcpMessage.params?.progressToken;
+            const progressValue = mcpMessage.params?.progress;
+            if (
+              progressToken !== undefined &&
+              typeof progressValue === 'number' &&
+              Number.isFinite(progressValue)
+            ) {
+              session.supportsOversizedTransfer = true;
+              await this.sendAcceptFrame({
+                clientPubkey: event.pubkey,
+                progressToken: String(progressToken),
+                progress: progressValue + 1,
+                correlatedEventId: event.id,
+              });
+            }
+          }
+
+          if (!synthetic) {
+            return;
+          }
+
+          session.supportsOversizedTransfer = true;
+          dispatchMessage = synthetic;
+
+          if (isJSONRPCRequest(synthetic)) {
+            this.handleIncomingRequest(
+              event.id,
+              synthetic,
+              event.pubkey,
+              wrapKind,
+            );
+
+            if (this.injectClientPubkey) {
+              injectClientPubkey(synthetic, event.pubkey);
+            }
+          } else if (isJSONRPCNotification(synthetic)) {
+            this.handleIncomingNotification(event.pubkey, synthetic);
+          }
+        } else {
+          this.handleIncomingNotification(event.pubkey, mcpMessage);
+        }
+      }
+
+      if (!dispatchMessage) {
+        return;
+      }
+
+      void dispatch(0, dispatchMessage).catch((err: unknown) => {
         this.logger.error('Error in inboundMiddleware chain', {
           error: err instanceof Error ? err.message : String(err),
           eventId: event.id,

--- a/src/transport/nostr-server/session-store.test.ts
+++ b/src/transport/nostr-server/session-store.test.ts
@@ -11,6 +11,7 @@ describe('SessionStore', () => {
       expect(created).toBe(true);
       expect(session.isEncrypted).toBe(true);
       expect(session.isInitialized).toBe(false);
+      expect(session.supportsOversizedTransfer).toBe(false);
       expect(store.getSession('client-1')).toBe(session);
     });
 

--- a/src/transport/nostr-server/session-store.ts
+++ b/src/transport/nostr-server/session-store.ts
@@ -18,6 +18,8 @@ export interface ClientSession {
   isEncrypted: boolean;
   /** Whether server common transport capability tags were already sent to this client */
   hasSentCommonTags: boolean;
+  /** Whether the client has advertised support for oversized transfer framing. */
+  supportsOversizedTransfer: boolean;
 }
 
 /**
@@ -75,6 +77,7 @@ export class SessionStore {
       isInitialized: false,
       isEncrypted,
       hasSentCommonTags: false,
+      supportsOversizedTransfer: false,
     };
 
     this.sessions.set(clientPubkey, newSession);

--- a/src/transport/nostr-transport-oversized-transfer.test.ts
+++ b/src/transport/nostr-transport-oversized-transfer.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { generateSecretKey, getPublicKey } from 'nostr-tools';
+import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
+import { z } from 'zod';
+import { NostrClientTransport } from './nostr-client-transport.js';
+import { NostrServerTransport } from './nostr-server-transport.js';
+import { MockRelayHub } from '../__mocks__/mock-relay-handler.js';
+import { PrivateKeySigner } from '../signer/private-key-signer.js';
+import { EncryptionMode } from '../core/interfaces.js';
+
+describe.serial('Nostr transport oversized transfer', () => {
+  test('round-trips oversized request and oversized response with progress framing', async () => {
+    const relayHub = new MockRelayHub();
+    const serverPrivateKey = bytesToHex(generateSecretKey());
+    const serverPublicKey = getPublicKey(hexToBytes(serverPrivateKey));
+
+    const server = new McpServer({
+      name: 'Oversized Server',
+      version: '1.0.0',
+    });
+
+    server.registerTool(
+      'roundtrip_large',
+      {
+        title: 'Roundtrip Large',
+        description: 'Echoes a large payload back to the client',
+        inputSchema: {
+          payload: z.string(),
+        },
+      },
+      async ({ payload }) => ({
+        content: [{ type: 'text', text: payload }],
+      }),
+    );
+
+    const serverTransport = new NostrServerTransport({
+      signer: new PrivateKeySigner(serverPrivateKey),
+      relayHandler: relayHub.createRelayHandler(),
+      encryptionMode: EncryptionMode.DISABLED,
+      oversizedTransfer: {
+        enabled: true,
+        thresholdBytes: 256,
+        chunkSizeBytes: 96,
+      },
+    });
+
+    await server.connect(serverTransport);
+
+    const clientPrivateKey = bytesToHex(generateSecretKey());
+    const clientTransport = new NostrClientTransport({
+      signer: new PrivateKeySigner(clientPrivateKey),
+      relayHandler: relayHub.createRelayHandler(),
+      serverPubkey: serverPublicKey,
+      encryptionMode: EncryptionMode.DISABLED,
+      oversizedTransfer: {
+        enabled: true,
+        thresholdBytes: 256,
+        chunkSizeBytes: 96,
+      },
+    });
+
+    const client = new Client({
+      name: 'Oversized Client',
+      version: '1.0.0',
+    });
+
+    await client.connect(clientTransport);
+
+    const payload = 'x'.repeat(8_000);
+    const result = await client.callTool(
+      {
+        name: 'roundtrip_large',
+        arguments: {
+          payload,
+        },
+      },
+      undefined,
+      {
+        onprogress: () => undefined,
+        resetTimeoutOnProgress: true,
+      },
+    );
+
+    const typedResult = result as {
+      content: Array<{ type: string; text?: string }>;
+    };
+
+    expect(typedResult.content[0]).toMatchObject({
+      type: 'text',
+      text: payload,
+    });
+
+    await client.close();
+    await server.close();
+    relayHub.clear();
+  }, 30000);
+});

--- a/src/transport/oversized-transfer/constants.ts
+++ b/src/transport/oversized-transfer/constants.ts
@@ -1,0 +1,31 @@
+export const OVERSIZED_TRANSFER_TYPE = 'oversized-transfer';
+
+/**
+ * Conservative proactive threshold for switching to framed transfer.
+ *
+ * This is lower than common relay payload limits to leave room for
+ * Nostr envelope serialization overhead and tags.
+ */
+export const DEFAULT_OVERSIZED_THRESHOLD_BYTES = 48_000;
+
+/**
+ * Maximum UTF-8 bytes in each framed chunk payload.
+ *
+ * Kept deliberately below the threshold to account for escaping overhead in
+ * the nested JSON string carried by notifications/progress.
+ */
+export const DEFAULT_CHUNK_SIZE_BYTES = 24_000;
+
+export const DIGEST_PREFIX = 'sha256:';
+
+/** Maximum accepted total payload size for one transfer. */
+export const DEFAULT_MAX_TRANSFER_BYTES = 100 * 1024 * 1024; // 100 MiB
+
+/** Maximum accepted chunk count for one transfer. */
+export const DEFAULT_MAX_TRANSFER_CHUNKS = 10_000;
+
+/** Hard timeout for one in-flight transfer. */
+export const DEFAULT_TRANSFER_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Max number of concurrent in-flight transfers per receiver instance. */
+export const DEFAULT_MAX_CONCURRENT_TRANSFERS = 64;

--- a/src/transport/oversized-transfer/errors.ts
+++ b/src/transport/oversized-transfer/errors.ts
@@ -1,0 +1,44 @@
+/** Base class for oversized transfer failures. */
+export class OversizedTransferError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OversizedTransferError';
+  }
+}
+
+/** Raised when the remote peer explicitly aborts a transfer. */
+export class OversizedTransferAbortError extends OversizedTransferError {
+  public readonly token: string;
+  public readonly reason: string | undefined;
+
+  constructor(token: string, reason?: string) {
+    super(`Transfer aborted${reason ? `: ${reason}` : ''}`);
+    this.name = 'OversizedTransferAbortError';
+    this.token = token;
+    this.reason = reason;
+  }
+}
+
+/** Raised when declared transfer parameters violate local policy limits. */
+export class OversizedTransferPolicyError extends OversizedTransferError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OversizedTransferPolicyError';
+  }
+}
+
+/** Raised when framing/order rules are invalid for a transfer. */
+export class OversizedTransferProtocolError extends OversizedTransferError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OversizedTransferProtocolError';
+  }
+}
+
+/** Raised when reconstructed payload length or digest does not match start frame. */
+export class OversizedTransferIntegrityError extends OversizedTransferError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OversizedTransferIntegrityError';
+  }
+}

--- a/src/transport/oversized-transfer/index.ts
+++ b/src/transport/oversized-transfer/index.ts
@@ -1,0 +1,5 @@
+export * from './constants.js';
+export * from './errors.js';
+export * from './types.js';
+export * from './sender.js';
+export * from './receiver.js';

--- a/src/transport/oversized-transfer/receiver.test.ts
+++ b/src/transport/oversized-transfer/receiver.test.ts
@@ -121,4 +121,56 @@ describe('OversizedTransferReceiver', () => {
 
     await expect(receiver.waitForAccept('token-r4', 100)).resolves.toBeUndefined();
   });
+
+  test('reassembles transfer with reserved accept slot and no inbound accept frame', () => {
+    const receiver = new OversizedTransferReceiver();
+    const payload = {
+      jsonrpc: '2.0' as const,
+      id: 'reserved-gap',
+      result: { text: 'handshake-required path' },
+    };
+    const serialized = JSON.stringify(payload);
+
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      serialized,
+      {
+        progressToken: 'token-r5',
+        chunkSizeBytes: 8,
+        needsAcceptHandshake: true,
+      },
+    );
+
+    expect(startFrame.progress).toBe(1);
+    expect(chunkFrames[0]?.progress).toBe(3);
+
+    receiver.processFrame(toProgressNotification(startFrame));
+    for (const chunkFrame of chunkFrames) {
+      receiver.processFrame(toProgressNotification(chunkFrame));
+    }
+
+    const synthetic = receiver.processFrame(toProgressNotification(endFrame));
+    expect(synthetic).toEqual(payload);
+  });
+
+  test('does not retain stale early accept after waiter resolution', async () => {
+    const receiver = new OversizedTransferReceiver();
+
+    const waiter = receiver.waitForAccept('token-r6', 100);
+    receiver.processFrame(
+      toProgressNotification({
+        progressToken: 'token-r6',
+        progress: 2,
+        cvm: {
+          type: 'oversized-transfer',
+          frameType: 'accept',
+        },
+      }),
+    );
+
+    await expect(waiter).resolves.toBeUndefined();
+
+    await expect(receiver.waitForAccept('token-r6', 20)).rejects.toThrow(
+      'Timed out waiting for oversized transfer accept',
+    );
+  });
 });

--- a/src/transport/oversized-transfer/receiver.test.ts
+++ b/src/transport/oversized-transfer/receiver.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test';
+import type { JSONRPCNotification } from '@modelcontextprotocol/sdk/types.js';
+import {
+  OversizedTransferIntegrityError,
+  OversizedTransferProtocolError,
+} from './errors.js';
+import { OversizedTransferReceiver } from './receiver.js';
+import { buildOversizedTransferFrames } from './sender.js';
+import type { OversizedTransferProgressParams } from './types.js';
+
+function toProgressNotification(
+  params: OversizedTransferProgressParams,
+): JSONRPCNotification {
+  return {
+    jsonrpc: '2.0',
+    method: 'notifications/progress',
+    params,
+  };
+}
+
+describe('OversizedTransferReceiver', () => {
+  test('reassembles out-of-order chunks and returns the synthetic JSON-RPC message', () => {
+    const receiver = new OversizedTransferReceiver();
+    const payload = {
+      jsonrpc: '2.0' as const,
+      id: 'abc',
+      result: { text: 'hello from oversized transfer' },
+    };
+    const serialized = JSON.stringify(payload);
+
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      serialized,
+      {
+        progressToken: 'token-r1',
+        chunkSizeBytes: 8,
+      },
+    );
+
+    expect(receiver.processFrame(toProgressNotification(startFrame))).toBeNull();
+
+    const shuffled = [...chunkFrames].reverse();
+    for (const chunkFrame of shuffled) {
+      expect(receiver.processFrame(toProgressNotification(chunkFrame))).toBeNull();
+    }
+
+    const synthetic = receiver.processFrame(toProgressNotification(endFrame));
+    expect(synthetic).toEqual(payload);
+  });
+
+  test('throws integrity error when digest does not match reassembled payload', () => {
+    const receiver = new OversizedTransferReceiver();
+    const serialized = JSON.stringify({ jsonrpc: '2.0', id: 1, result: { ok: 1 } });
+
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      serialized,
+      {
+        progressToken: 'token-r2',
+        chunkSizeBytes: 16,
+      },
+    );
+
+    if (startFrame.cvm.frameType !== 'start') {
+      throw new Error('expected start frame');
+    }
+
+    const tamperedStart: OversizedTransferProgressParams = {
+      ...startFrame,
+      cvm: {
+        ...startFrame.cvm,
+        digest: 'sha256:deadbeef',
+      },
+    };
+
+    receiver.processFrame(toProgressNotification(tamperedStart));
+    for (const chunkFrame of chunkFrames) {
+      receiver.processFrame(toProgressNotification(chunkFrame));
+    }
+
+    expect(() => receiver.processFrame(toProgressNotification(endFrame))).toThrow(
+      OversizedTransferIntegrityError,
+    );
+  });
+
+  test('throws protocol error when end arrives with missing chunks', () => {
+    const receiver = new OversizedTransferReceiver();
+    const serialized = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { very: 'large payload' },
+    });
+
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      serialized,
+      {
+        progressToken: 'token-r3',
+        chunkSizeBytes: 6,
+      },
+    );
+
+    receiver.processFrame(toProgressNotification(startFrame));
+    receiver.processFrame(toProgressNotification(chunkFrames[0]!));
+
+    expect(() => receiver.processFrame(toProgressNotification(endFrame))).toThrow(
+      OversizedTransferProtocolError,
+    );
+  });
+
+  test('resolves waitForAccept when accept arrives before waiter registration', async () => {
+    const receiver = new OversizedTransferReceiver();
+
+    const accept = toProgressNotification({
+      progressToken: 'token-r4',
+      progress: 2,
+      cvm: {
+        type: 'oversized-transfer',
+        frameType: 'accept',
+      },
+    });
+
+    receiver.processFrame(accept);
+
+    await expect(receiver.waitForAccept('token-r4', 100)).resolves.toBeUndefined();
+  });
+});

--- a/src/transport/oversized-transfer/receiver.ts
+++ b/src/transport/oversized-transfer/receiver.ts
@@ -1,0 +1,728 @@
+import {
+  JSONRPCMessageSchema,
+  type JSONRPCMessage,
+  type JSONRPCNotification,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Logger } from '../../core/utils/logger.js';
+import {
+  DEFAULT_MAX_CONCURRENT_TRANSFERS,
+  DEFAULT_MAX_TRANSFER_BYTES,
+  DEFAULT_MAX_TRANSFER_CHUNKS,
+  DEFAULT_TRANSFER_TIMEOUT_MS,
+  DIGEST_PREFIX,
+  OVERSIZED_TRANSFER_TYPE,
+} from './constants.js';
+import {
+  OversizedTransferAbortError,
+  OversizedTransferError,
+  OversizedTransferIntegrityError,
+  OversizedTransferPolicyError,
+  OversizedTransferProtocolError,
+} from './errors.js';
+import { sha256Digest, utf8ByteLength } from './sender.js';
+import type {
+  OversizedTransferAbortFrame,
+  OversizedTransferAcceptFrame,
+  OversizedTransferChunkFrame,
+  OversizedTransferEndFrame,
+  OversizedTransferFrameParseResult,
+  OversizedTransferProgressNotification,
+  OversizedTransferStartFrame,
+  OversizedTransferSyntheticResult,
+} from './types.js';
+
+export interface TransferPolicy {
+  /** Maximum accepted bytes declared by `start.totalBytes`. */
+  maxTransferBytes?: number;
+  /** Maximum accepted chunks declared by `start.totalChunks`. */
+  maxTransferChunks?: number;
+  /** Hard timeout for an in-flight transfer. */
+  transferTimeoutMs?: number;
+  /** Maximum number of concurrent in-flight transfers. */
+  maxConcurrentTransfers?: number;
+}
+
+type OversizedTransferLogger = Pick<Logger, 'debug' | 'warn' | 'error'>;
+
+type ActiveTransfer = {
+  token: string;
+  startProgress: number;
+  acceptProgress: number | undefined;
+  endProgress: number | undefined;
+  digest: string;
+  totalBytes: number;
+  totalChunks: number;
+  chunksByProgress: Map<number, string>;
+  bufferedChunkBytes: number;
+  timeoutHandle: ReturnType<typeof setTimeout>;
+};
+
+type AcceptWaiter = {
+  resolve: () => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parsePositiveInteger(
+  value: unknown,
+  label: string,
+): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new OversizedTransferProtocolError(
+      `Invalid ${label} value for oversized transfer frame`,
+    );
+  }
+  return value;
+}
+
+function parseFrame(
+  notification: JSONRPCNotification,
+): OversizedTransferFrameParseResult | null {
+  if (notification.method !== 'notifications/progress') {
+    return null;
+  }
+
+  const params = notification.params;
+  if (!isRecord(params)) {
+    return null;
+  }
+
+  const cvm = params.cvm;
+  if (!isRecord(cvm) || cvm.type !== OVERSIZED_TRANSFER_TYPE) {
+    return null;
+  }
+
+  const tokenRaw = params.progressToken;
+  if (!(typeof tokenRaw === 'string' || typeof tokenRaw === 'number')) {
+    throw new OversizedTransferProtocolError(
+      'Missing or invalid progressToken for oversized transfer frame',
+    );
+  }
+
+  const progress = parsePositiveInteger(params.progress, 'progress');
+  const token = String(tokenRaw);
+
+  const frameType = cvm.frameType;
+  if (typeof frameType !== 'string') {
+    throw new OversizedTransferProtocolError(
+      'Missing frameType for oversized transfer frame',
+    );
+  }
+
+  switch (frameType) {
+    case 'start': {
+      if (cvm.completionMode !== 'render') {
+        throw new OversizedTransferProtocolError(
+          'Unsupported completionMode for oversized transfer start frame',
+        );
+      }
+
+      if (typeof cvm.digest !== 'string') {
+        throw new OversizedTransferProtocolError(
+          'Missing digest in oversized transfer start frame',
+        );
+      }
+
+      const totalBytes = parsePositiveInteger(cvm.totalBytes, 'totalBytes');
+      const totalChunks = parsePositiveInteger(cvm.totalChunks, 'totalChunks');
+
+      const frame: OversizedTransferStartFrame = {
+        type: OVERSIZED_TRANSFER_TYPE,
+        frameType: 'start',
+        completionMode: 'render',
+        digest: cvm.digest,
+        totalBytes,
+        totalChunks,
+      };
+
+      return {
+        token,
+        progress,
+        frame,
+      };
+    }
+
+    case 'accept': {
+      const frame: OversizedTransferAcceptFrame = {
+        type: OVERSIZED_TRANSFER_TYPE,
+        frameType: 'accept',
+      };
+
+      return {
+        token,
+        progress,
+        frame,
+      };
+    }
+
+    case 'chunk': {
+      if (typeof cvm.data !== 'string') {
+        throw new OversizedTransferProtocolError(
+          'Missing data in oversized transfer chunk frame',
+        );
+      }
+
+      const frame: OversizedTransferChunkFrame = {
+        type: OVERSIZED_TRANSFER_TYPE,
+        frameType: 'chunk',
+        data: cvm.data,
+      };
+
+      return {
+        token,
+        progress,
+        frame,
+      };
+    }
+
+    case 'end': {
+      const frame: OversizedTransferEndFrame = {
+        type: OVERSIZED_TRANSFER_TYPE,
+        frameType: 'end',
+      };
+
+      return {
+        token,
+        progress,
+        frame,
+      };
+    }
+
+    case 'abort': {
+      if (cvm.reason !== undefined && typeof cvm.reason !== 'string') {
+        throw new OversizedTransferProtocolError(
+          'Invalid reason in oversized transfer abort frame',
+        );
+      }
+
+      const frame: OversizedTransferAbortFrame = {
+        type: OVERSIZED_TRANSFER_TYPE,
+        frameType: 'abort',
+        reason: cvm.reason,
+      };
+
+      return {
+        token,
+        progress,
+        frame,
+      };
+    }
+
+    default:
+      throw new OversizedTransferProtocolError(
+        `Unsupported frameType for oversized transfer: ${String(frameType)}`,
+      );
+  }
+}
+
+const NOOP_LOGGER: OversizedTransferLogger = {
+  debug: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+/**
+ * Stateful reassembly engine for framed oversized transfers.
+ */
+export class OversizedTransferReceiver {
+  private readonly maxTransferBytes: number;
+  private readonly maxTransferChunks: number;
+  private readonly transferTimeoutMs: number;
+  private readonly maxConcurrentTransfers: number;
+
+  private readonly transfers = new Map<string, ActiveTransfer>();
+  private readonly acceptWaiters = new Map<string, AcceptWaiter>();
+  private readonly earlyAccepts = new Map<string, number>();
+  private readonly logger: OversizedTransferLogger;
+
+  constructor(policy: TransferPolicy = {}, logger?: OversizedTransferLogger) {
+    this.maxTransferBytes =
+      policy.maxTransferBytes ?? DEFAULT_MAX_TRANSFER_BYTES;
+    this.maxTransferChunks =
+      policy.maxTransferChunks ?? DEFAULT_MAX_TRANSFER_CHUNKS;
+    this.transferTimeoutMs =
+      policy.transferTimeoutMs ?? DEFAULT_TRANSFER_TIMEOUT_MS;
+    this.maxConcurrentTransfers =
+      policy.maxConcurrentTransfers ?? DEFAULT_MAX_CONCURRENT_TRANSFERS;
+    this.logger = logger ?? NOOP_LOGGER;
+  }
+
+  public static isOversizedFrame(
+    message: JSONRPCMessage,
+  ): message is OversizedTransferProgressNotification {
+    if (
+      !('method' in message) ||
+      message.method !== 'notifications/progress' ||
+      !isRecord(message.params)
+    ) {
+      return false;
+    }
+
+    const cvm = message.params.cvm;
+    return isRecord(cvm) && cvm.type === OVERSIZED_TRANSFER_TYPE;
+  }
+
+  /**
+   * Wait for an `accept` frame associated with a transfer token.
+   */
+  public waitForAccept(
+    token: string,
+    timeoutMs: number = this.transferTimeoutMs,
+  ): Promise<void> {
+    const now = Date.now();
+    this.pruneEarlyAccepts(now);
+
+    const earlyAcceptExpiry = this.earlyAccepts.get(token);
+    if (earlyAcceptExpiry !== undefined && earlyAcceptExpiry > now) {
+      this.earlyAccepts.delete(token);
+      return Promise.resolve();
+    }
+
+    this.rejectAcceptWaiter(
+      token,
+      new OversizedTransferError(
+        `Superseded oversized transfer accept waiter (token: ${token})`,
+      ),
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.acceptWaiters.delete(token);
+        reject(
+          new OversizedTransferError(
+            `Timed out waiting for oversized transfer accept (token: ${token})`,
+          ),
+        );
+      }, timeoutMs);
+
+      this.acceptWaiters.set(token, {
+        resolve,
+        reject,
+        timer,
+      });
+    });
+  }
+
+  /**
+   * Process one `notifications/progress` frame.
+   */
+  public processFrame(
+    notification: JSONRPCNotification,
+  ): OversizedTransferSyntheticResult {
+    const parsed = parseFrame(notification);
+    if (!parsed) {
+      return null;
+    }
+
+    switch (parsed.frame.frameType) {
+      case 'start':
+        this.handleStart(parsed.token, parsed.progress, parsed.frame);
+        return null;
+      case 'accept':
+        this.handleAccept(parsed.token, parsed.progress);
+        return null;
+      case 'chunk':
+        this.handleChunk(parsed.token, parsed.progress, parsed.frame);
+        return null;
+      case 'end':
+        return this.handleEnd(parsed.token, parsed.progress);
+      case 'abort':
+        return this.handleAbort(parsed.token, parsed.frame);
+      default:
+        return null;
+    }
+  }
+
+  public get activeTransferCount(): number {
+    return this.transfers.size;
+  }
+
+  /**
+   * Release all active state and reject pending accept waiters.
+   */
+  public clear(): void {
+    for (const transfer of this.transfers.values()) {
+      clearTimeout(transfer.timeoutHandle);
+    }
+
+    for (const waiter of this.acceptWaiters.values()) {
+      clearTimeout(waiter.timer);
+      waiter.reject(new OversizedTransferError('Oversized receiver cleared'));
+    }
+
+    this.transfers.clear();
+    this.acceptWaiters.clear();
+    this.earlyAccepts.clear();
+  }
+
+  private handleStart(
+    token: string,
+    progress: number,
+    frame: OversizedTransferStartFrame,
+  ): void {
+    const existing = this.transfers.get(token);
+    if (existing) {
+      const isDuplicateStart =
+        existing.startProgress === progress &&
+        existing.digest === frame.digest &&
+        existing.totalBytes === frame.totalBytes &&
+        existing.totalChunks === frame.totalChunks;
+
+      if (isDuplicateStart) {
+        return;
+      }
+
+      throw new OversizedTransferProtocolError(
+        `Received duplicate start for active oversized transfer token: ${token}`,
+      );
+    }
+
+    if (this.transfers.size >= this.maxConcurrentTransfers) {
+      throw new OversizedTransferPolicyError(
+        `Too many concurrent oversized transfers (max: ${this.maxConcurrentTransfers})`,
+      );
+    }
+
+    if (frame.totalBytes > this.maxTransferBytes) {
+      throw new OversizedTransferPolicyError(
+        `Oversized transfer exceeds byte policy (token: ${token}, declared: ${frame.totalBytes}, max: ${this.maxTransferBytes})`,
+      );
+    }
+
+    if (frame.totalChunks > this.maxTransferChunks) {
+      throw new OversizedTransferPolicyError(
+        `Oversized transfer exceeds chunk policy (token: ${token}, declared: ${frame.totalChunks}, max: ${this.maxTransferChunks})`,
+      );
+    }
+
+    if (!frame.digest.startsWith(DIGEST_PREFIX)) {
+      throw new OversizedTransferProtocolError(
+        `Invalid digest format in oversized transfer start frame (token: ${token})`,
+      );
+    }
+
+    const transfer: ActiveTransfer = {
+      token,
+      startProgress: progress,
+      acceptProgress: undefined,
+      endProgress: undefined,
+      digest: frame.digest,
+      totalBytes: frame.totalBytes,
+      totalChunks: frame.totalChunks,
+      chunksByProgress: new Map<number, string>(),
+      bufferedChunkBytes: 0,
+      timeoutHandle: this.createTransferTimeout(token),
+    };
+
+    this.transfers.set(token, transfer);
+  }
+
+  private handleAccept(token: string, progress: number): void {
+    this.resolveAcceptWaiter(token);
+
+    const transfer = this.transfers.get(token);
+    if (!transfer) {
+      const expiresAt = Date.now() + this.transferTimeoutMs;
+      this.earlyAccepts.set(token, expiresAt);
+      this.pruneEarlyAccepts(Date.now());
+      return;
+    }
+
+    if (progress <= transfer.startProgress) {
+      throw new OversizedTransferProtocolError(
+        `Non-monotonic accept progress in oversized transfer (token: ${token})`,
+      );
+    }
+
+    if (transfer.endProgress !== undefined && progress >= transfer.endProgress) {
+      throw new OversizedTransferProtocolError(
+        `Accept progress must be lower than end progress (token: ${token})`,
+      );
+    }
+
+    if (transfer.acceptProgress !== undefined) {
+      if (transfer.acceptProgress !== progress) {
+        throw new OversizedTransferProtocolError(
+          `Conflicting duplicate accept frame for oversized transfer (token: ${token})`,
+        );
+      }
+      return;
+    }
+
+    transfer.acceptProgress = progress;
+    this.touchTransfer(token, transfer);
+  }
+
+  private handleChunk(
+    token: string,
+    progress: number,
+    frame: OversizedTransferChunkFrame,
+  ): void {
+    const transfer = this.transfers.get(token);
+    if (!transfer) {
+      this.logger.warn('Ignoring chunk for unknown oversized transfer token', {
+        token,
+        progress,
+      });
+      return;
+    }
+
+    if (progress <= transfer.startProgress) {
+      this.cleanupTransfer(token);
+      throw new OversizedTransferProtocolError(
+        `Chunk progress must be greater than start progress (token: ${token})`,
+      );
+    }
+
+    if (
+      transfer.acceptProgress !== undefined &&
+      progress <= transfer.acceptProgress
+    ) {
+      this.cleanupTransfer(token);
+      throw new OversizedTransferProtocolError(
+        `Chunk progress must be greater than accept progress (token: ${token})`,
+      );
+    }
+
+    if (transfer.endProgress !== undefined && progress >= transfer.endProgress) {
+      this.cleanupTransfer(token);
+      throw new OversizedTransferProtocolError(
+        `Chunk progress must be lower than end progress (token: ${token})`,
+      );
+    }
+
+    const previousChunk = transfer.chunksByProgress.get(progress);
+    if (previousChunk !== undefined) {
+      if (previousChunk !== frame.data) {
+        this.cleanupTransfer(token);
+        throw new OversizedTransferProtocolError(
+          `Conflicting duplicate chunk frame in oversized transfer (token: ${token}, progress: ${progress})`,
+        );
+      }
+      return;
+    }
+
+    transfer.chunksByProgress.set(progress, frame.data);
+    transfer.bufferedChunkBytes += utf8ByteLength(frame.data);
+
+    if (transfer.chunksByProgress.size > transfer.totalChunks) {
+      this.cleanupTransfer(token);
+      throw new OversizedTransferProtocolError(
+        `Received more chunks than declared in start frame (token: ${token})`,
+      );
+    }
+
+    if (transfer.bufferedChunkBytes > transfer.totalBytes) {
+      this.cleanupTransfer(token);
+      throw new OversizedTransferProtocolError(
+        `Buffered chunk bytes exceed declared totalBytes (token: ${token})`,
+      );
+    }
+
+    this.touchTransfer(token, transfer);
+  }
+
+  private handleEnd(token: string, progress: number): JSONRPCMessage | null {
+    const transfer = this.transfers.get(token);
+    if (!transfer) {
+      this.logger.warn('Ignoring end for unknown oversized transfer token', {
+        token,
+        progress,
+      });
+      return null;
+    }
+
+    try {
+      if (progress <= transfer.startProgress) {
+        throw new OversizedTransferProtocolError(
+          `End progress must be greater than start progress (token: ${token})`,
+        );
+      }
+
+      if (
+        transfer.acceptProgress !== undefined &&
+        progress <= transfer.acceptProgress
+      ) {
+        throw new OversizedTransferProtocolError(
+          `End progress must be greater than accept progress (token: ${token})`,
+        );
+      }
+
+      if (transfer.endProgress !== undefined && transfer.endProgress !== progress) {
+        throw new OversizedTransferProtocolError(
+          `Conflicting duplicate end frame in oversized transfer (token: ${token})`,
+        );
+      }
+      transfer.endProgress = progress;
+
+      if (transfer.chunksByProgress.size !== transfer.totalChunks) {
+        throw new OversizedTransferProtocolError(
+          `Chunk completeness mismatch in oversized transfer (token: ${token}, expected: ${transfer.totalChunks}, received: ${transfer.chunksByProgress.size})`,
+        );
+      }
+
+      const sortedChunks = [...transfer.chunksByProgress.entries()].sort(
+        ([left], [right]) => left - right,
+      );
+
+      for (const [chunkProgress] of sortedChunks) {
+        if (chunkProgress >= progress) {
+          throw new OversizedTransferProtocolError(
+            `Chunk progress must be lower than end progress (token: ${token})`,
+          );
+        }
+
+        if (
+          transfer.acceptProgress !== undefined &&
+          chunkProgress <= transfer.acceptProgress
+        ) {
+          throw new OversizedTransferProtocolError(
+            `Chunk progress must be greater than accept progress (token: ${token})`,
+          );
+        }
+      }
+
+      const frameCountBetween = progress - transfer.startProgress - 1;
+      const expectedBetweenCount =
+        transfer.totalChunks + (transfer.acceptProgress !== undefined ? 1 : 0);
+
+      if (frameCountBetween !== expectedBetweenCount) {
+        throw new OversizedTransferProtocolError(
+          `Unresolved progress gaps in oversized transfer (token: ${token})`,
+        );
+      }
+
+      const assembled = sortedChunks.map(([, chunk]) => chunk).join('');
+
+      if (utf8ByteLength(assembled) !== transfer.totalBytes) {
+        throw new OversizedTransferIntegrityError(
+          `Byte-length mismatch in oversized transfer (token: ${token})`,
+        );
+      }
+
+      if (sha256Digest(assembled) !== transfer.digest) {
+        throw new OversizedTransferIntegrityError(
+          `Digest mismatch in oversized transfer (token: ${token})`,
+        );
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(assembled);
+      } catch (error) {
+        throw new OversizedTransferProtocolError(
+          `Reassembled oversized payload is not valid JSON (token: ${token}): ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
+      const validated = JSONRPCMessageSchema.safeParse(parsed);
+      if (!validated.success) {
+        throw new OversizedTransferProtocolError(
+          `Reassembled oversized payload is not a valid JSON-RPC message (token: ${token})`,
+        );
+      }
+
+      return validated.data;
+    } finally {
+      this.cleanupTransfer(token);
+    }
+  }
+
+  private handleAbort(
+    token: string,
+    frame: OversizedTransferAbortFrame,
+  ): OversizedTransferSyntheticResult {
+    const error = new OversizedTransferAbortError(token, frame.reason);
+    const hadTransfer = this.transfers.has(token);
+    const hadWaiter = this.rejectAcceptWaiter(token, error);
+    this.cleanupTransfer(token);
+
+    if (!hadTransfer && !hadWaiter) {
+      this.logger.warn('Ignoring abort for unknown oversized transfer token', {
+        token,
+      });
+      return null;
+    }
+
+    throw error;
+  }
+
+  private createTransferTimeout(
+    token: string,
+  ): ReturnType<typeof setTimeout> {
+    return setTimeout(() => {
+      this.cleanupTransfer(token);
+      this.rejectAcceptWaiter(
+        token,
+        new OversizedTransferError(
+          `Oversized transfer timed out (token: ${token})`,
+        ),
+      );
+      this.logger.warn('Oversized transfer timed out', { token });
+    }, this.transferTimeoutMs);
+  }
+
+  private touchTransfer(token: string, transfer: ActiveTransfer): void {
+    clearTimeout(transfer.timeoutHandle);
+    transfer.timeoutHandle = this.createTransferTimeout(token);
+  }
+
+  private cleanupTransfer(token: string): void {
+    const transfer = this.transfers.get(token);
+    if (!transfer) {
+      return;
+    }
+
+    clearTimeout(transfer.timeoutHandle);
+    this.transfers.delete(token);
+  }
+
+  private resolveAcceptWaiter(token: string): boolean {
+    const waiter = this.acceptWaiters.get(token);
+    if (!waiter) {
+      return false;
+    }
+
+    clearTimeout(waiter.timer);
+    this.acceptWaiters.delete(token);
+    waiter.resolve();
+    return true;
+  }
+
+  private rejectAcceptWaiter(token: string, error: Error): boolean {
+    const waiter = this.acceptWaiters.get(token);
+    if (!waiter) {
+      return false;
+    }
+
+    clearTimeout(waiter.timer);
+    this.acceptWaiters.delete(token);
+    waiter.reject(error);
+    return true;
+  }
+
+  private pruneEarlyAccepts(now: number): void {
+    for (const [token, expiresAt] of this.earlyAccepts.entries()) {
+      if (expiresAt <= now) {
+        this.earlyAccepts.delete(token);
+      }
+    }
+
+    while (this.earlyAccepts.size > this.maxConcurrentTransfers) {
+      const first = this.earlyAccepts.keys().next();
+      if (first.done) {
+        break;
+      }
+      this.earlyAccepts.delete(first.value);
+    }
+  }
+}

--- a/src/transport/oversized-transfer/receiver.ts
+++ b/src/transport/oversized-transfer/receiver.ts
@@ -427,13 +427,18 @@ export class OversizedTransferReceiver {
   }
 
   private handleAccept(token: string, progress: number): void {
-    this.resolveAcceptWaiter(token);
+    const resolvedWaiter = this.resolveAcceptWaiter(token);
+    if (resolvedWaiter) {
+      this.earlyAccepts.delete(token);
+    }
 
     const transfer = this.transfers.get(token);
     if (!transfer) {
-      const expiresAt = Date.now() + this.transferTimeoutMs;
-      this.earlyAccepts.set(token, expiresAt);
-      this.pruneEarlyAccepts(Date.now());
+      if (!resolvedWaiter) {
+        const expiresAt = Date.now() + this.transferTimeoutMs;
+        this.earlyAccepts.set(token, expiresAt);
+        this.pruneEarlyAccepts(Date.now());
+      }
       return;
     }
 
@@ -574,6 +579,12 @@ export class OversizedTransferReceiver {
         ([left], [right]) => left - right,
       );
 
+      const smallestChunkProgress = sortedChunks[0]?.[0];
+      const hasReservedAcceptSlot =
+        transfer.acceptProgress === undefined &&
+        smallestChunkProgress !== undefined &&
+        smallestChunkProgress === transfer.startProgress + 2;
+
       for (const [chunkProgress] of sortedChunks) {
         if (chunkProgress >= progress) {
           throw new OversizedTransferProtocolError(
@@ -593,7 +604,8 @@ export class OversizedTransferReceiver {
 
       const frameCountBetween = progress - transfer.startProgress - 1;
       const expectedBetweenCount =
-        transfer.totalChunks + (transfer.acceptProgress !== undefined ? 1 : 0);
+        transfer.totalChunks +
+        (transfer.acceptProgress !== undefined || hasReservedAcceptSlot ? 1 : 0);
 
       if (frameCountBetween !== expectedBetweenCount) {
         throw new OversizedTransferProtocolError(

--- a/src/transport/oversized-transfer/sender.test.ts
+++ b/src/transport/oversized-transfer/sender.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildOversizedTransferFrames,
+  sha256Digest,
+  utf8ByteLength,
+} from './sender.js';
+
+describe('buildOversizedTransferFrames', () => {
+  test('builds deterministic start/chunk/end frame sequence', () => {
+    const serialized = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { value: 'ok' },
+    });
+
+    const { startFrame, chunkFrames, endFrame } = buildOversizedTransferFrames(
+      serialized,
+      {
+        progressToken: 'token-1',
+        chunkSizeBytes: 8,
+      },
+    );
+
+    expect(startFrame.progress).toBe(1);
+    expect(startFrame.cvm.frameType).toBe('start');
+    if (startFrame.cvm.frameType !== 'start') {
+      throw new Error('expected start frame');
+    }
+
+    expect(startFrame.cvm.digest).toBe(sha256Digest(serialized));
+    expect(startFrame.cvm.totalBytes).toBe(utf8ByteLength(serialized));
+    expect(startFrame.cvm.totalChunks).toBe(chunkFrames.length);
+
+    expect(chunkFrames[0]?.progress).toBe(2);
+    expect(endFrame.progress).toBe(chunkFrames.length + 2);
+
+    const reconstructed = chunkFrames
+      .map((frame) => {
+        if (frame.cvm.frameType !== 'chunk') {
+          throw new Error('expected chunk frame');
+        }
+        return frame.cvm.data;
+      })
+      .join('');
+    expect(reconstructed).toBe(serialized);
+  });
+
+  test('reserves progress value 2 when accept handshake is required', () => {
+    const serialized = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'r1',
+      method: 'tools/call',
+      params: { name: 'x' },
+    });
+
+    const { chunkFrames, endFrame } = buildOversizedTransferFrames(serialized, {
+      progressToken: 'token-2',
+      chunkSizeBytes: 16,
+      needsAcceptHandshake: true,
+    });
+
+    expect(chunkFrames[0]?.progress).toBe(3);
+    expect(endFrame.progress).toBe(chunkFrames.length + 3);
+  });
+
+  test('preserves multi-byte UTF-8 characters in chunking', () => {
+    const serialized = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        text: 'A\u{1F600}B',
+      },
+    });
+
+    const { chunkFrames } = buildOversizedTransferFrames(serialized, {
+      progressToken: 'token-3',
+      chunkSizeBytes: 7,
+    });
+
+    const reconstructed = chunkFrames
+      .map((frame) => {
+        if (frame.cvm.frameType !== 'chunk') {
+          throw new Error('expected chunk frame');
+        }
+        return frame.cvm.data;
+      })
+      .join('');
+    expect(reconstructed).toBe(serialized);
+  });
+
+  test('throws when chunk size is invalid', () => {
+    expect(() =>
+      buildOversizedTransferFrames('{"jsonrpc":"2.0"}', {
+        progressToken: 'token-4',
+        chunkSizeBytes: 0,
+      }),
+    ).toThrow('Invalid chunkSizeBytes');
+  });
+});

--- a/src/transport/oversized-transfer/sender.ts
+++ b/src/transport/oversized-transfer/sender.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import {
+  DEFAULT_CHUNK_SIZE_BYTES,
+  DIGEST_PREFIX,
+  OVERSIZED_TRANSFER_TYPE,
+} from './constants.js';
+import type { OversizedTransferProgressParams } from './types.js';
+
+export interface OversizedSenderOptions {
+  progressToken: string;
+  chunkSizeBytes?: number;
+  /**
+   * When true, reserves progress value 2 for receiver `accept` and starts
+   * chunks at progress value 3.
+   */
+  needsAcceptHandshake?: boolean;
+}
+
+export interface OversizedFrameBundle {
+  startFrame: OversizedTransferProgressParams;
+  chunkFrames: OversizedTransferProgressParams[];
+  endFrame: OversizedTransferProgressParams;
+}
+
+export function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+export function sha256Digest(value: string): string {
+  return `${DIGEST_PREFIX}${createHash('sha256').update(value, 'utf8').digest('hex')}`;
+}
+
+function splitStringByUtf8ByteSize(value: string, maxBytes: number): string[] {
+  if (!Number.isInteger(maxBytes) || maxBytes <= 0) {
+    throw new Error(`Invalid chunkSizeBytes: ${maxBytes}`);
+  }
+
+  const chunks: string[] = [];
+  let currentChars: string[] = [];
+  let currentBytes = 0;
+
+  for (const char of value) {
+    const charBytes = utf8ByteLength(char);
+    if (charBytes > maxBytes) {
+      throw new Error(
+        `Unable to split message: single character exceeds chunk size (${charBytes} > ${maxBytes})`,
+      );
+    }
+
+    if (currentBytes > 0 && currentBytes + charBytes > maxBytes) {
+      chunks.push(currentChars.join(''));
+      currentChars = [char];
+      currentBytes = charBytes;
+      continue;
+    }
+
+    currentChars.push(char);
+    currentBytes += charBytes;
+  }
+
+  if (currentChars.length > 0) {
+    chunks.push(currentChars.join(''));
+  }
+
+  return chunks;
+}
+
+/**
+ * Build an ordered oversized-transfer frame bundle for one serialized message.
+ */
+export function buildOversizedTransferFrames(
+  serializedMessage: string,
+  options: OversizedSenderOptions,
+): OversizedFrameBundle {
+  const chunkSizeBytes = options.chunkSizeBytes ?? DEFAULT_CHUNK_SIZE_BYTES;
+  const chunkPayloads = splitStringByUtf8ByteSize(serializedMessage, chunkSizeBytes);
+
+  const totalBytes = utf8ByteLength(serializedMessage);
+  const totalChunks = chunkPayloads.length;
+  const chunkStartProgress = options.needsAcceptHandshake ? 3 : 2;
+
+  const startFrame: OversizedTransferProgressParams = {
+    progressToken: options.progressToken,
+    progress: 1,
+    message: 'starting oversized transfer',
+    cvm: {
+      type: OVERSIZED_TRANSFER_TYPE,
+      frameType: 'start',
+      completionMode: 'render',
+      digest: sha256Digest(serializedMessage),
+      totalBytes,
+      totalChunks,
+    },
+  };
+
+  const chunkFrames: OversizedTransferProgressParams[] = chunkPayloads.map(
+    (chunkData, index) => ({
+      progressToken: options.progressToken,
+      progress: chunkStartProgress + index,
+      cvm: {
+        type: OVERSIZED_TRANSFER_TYPE,
+        frameType: 'chunk',
+        data: chunkData,
+      },
+    }),
+  );
+
+  const endFrame: OversizedTransferProgressParams = {
+    progressToken: options.progressToken,
+    progress: chunkStartProgress + totalChunks,
+    message: 'oversized transfer complete',
+    cvm: {
+      type: OVERSIZED_TRANSFER_TYPE,
+      frameType: 'end',
+    },
+  };
+
+  return {
+    startFrame,
+    chunkFrames,
+    endFrame,
+  };
+}

--- a/src/transport/oversized-transfer/types.ts
+++ b/src/transport/oversized-transfer/types.ts
@@ -1,0 +1,70 @@
+import type {
+  JSONRPCMessage,
+  JSONRPCNotification,
+} from '@modelcontextprotocol/sdk/types.js';
+
+export type OversizedTransferFrameType =
+  | 'start'
+  | 'accept'
+  | 'chunk'
+  | 'end'
+  | 'abort';
+
+export type OversizedTransferCommonFrame = {
+  type: 'oversized-transfer';
+  frameType: OversizedTransferFrameType;
+};
+
+export type OversizedTransferStartFrame = OversizedTransferCommonFrame & {
+  frameType: 'start';
+  completionMode: 'render';
+  digest: string;
+  totalBytes: number;
+  totalChunks: number;
+};
+
+export type OversizedTransferAcceptFrame = OversizedTransferCommonFrame & {
+  frameType: 'accept';
+};
+
+export type OversizedTransferChunkFrame = OversizedTransferCommonFrame & {
+  frameType: 'chunk';
+  data: string;
+};
+
+export type OversizedTransferEndFrame = OversizedTransferCommonFrame & {
+  frameType: 'end';
+};
+
+export type OversizedTransferAbortFrame = OversizedTransferCommonFrame & {
+  frameType: 'abort';
+  reason?: string;
+};
+
+export type OversizedTransferFrame =
+  | OversizedTransferStartFrame
+  | OversizedTransferAcceptFrame
+  | OversizedTransferChunkFrame
+  | OversizedTransferEndFrame
+  | OversizedTransferAbortFrame;
+
+export type OversizedTransferProgressParams = {
+  progressToken: string | number;
+  progress: number;
+  message?: string;
+  total?: number;
+  cvm: OversizedTransferFrame;
+};
+
+export type OversizedTransferProgressNotification = JSONRPCNotification & {
+  method: 'notifications/progress';
+  params: OversizedTransferProgressParams;
+};
+
+export type OversizedTransferFrameParseResult = {
+  token: string;
+  progress: number;
+  frame: OversizedTransferFrame;
+};
+
+export type OversizedTransferSyntheticResult = JSONRPCMessage | null;


### PR DESCRIPTION
This PR implements the CEP-22 discussed method(https://github.com/ContextVM/contextvm-docs/issues/22#issuecomment-4172838310)

## Summary

This PR implements **bounded oversized payload transfer** for ContextVM transport using MCP notifications/progress framing, with strict reassembly validation and safe fallback behavior.

It introduces a complete framing lifecycle (`start`, `accept`, `chunk`, `end`, `abort`), reconstructs the exact serialized JSON-RPC message in render mode, verifies SHA-256 digest and byte length, and only then emits the synthetic request/response.

---

## Problem

Large JSON-RPC payloads can exceed relay event limits and fail publication, even when the logical MCP operation itself is valid.

This PR introduces a robust transfer profile to safely handle oversized payloads.

---

## What Changed

### Core Transfer Primitives & Policy Controls
Added in:
- `constants.ts`
- `types.ts`
- `errors.ts`
- `sender.ts`
- `receiver.ts`
- `index.ts`

### Client-Side Integration
- Proactive oversized request framing
- Inbound frame reconstruction

Updated:
- `nostr-client-transport.ts`

### Server-Side Integration
- Inbound oversized request reconstruction
- Accept handshake emission
- Proactive oversized response framing

Updated:
- `nostr-server-transport.ts`

### Capability Advertisement
- Added `support_oversized_transfer` tag

Updated:
- `constants.ts`

### Public API Surface
- Exported oversized transfer functionality

Updated:
- `index.ts`

### Session Awareness
- Per-session capability tracking for routing behavior

Added/Updated:
- `session-store.ts`
- `session-store.test.ts`

---

## CEP Mapping

- **Capability Advertisement**  
  `support_oversized_transfer` tag is learned and advertised.

- **Request-Level Activation**  
  Oversized flow is triggered only when a request includes `progressToken`.

- **Sender Behavior**  
  - Proactive fragmentation above threshold  
  - Client waits for `accept` when support is unknown  

- **Framing Transport**  
  MCP `notifications/progress` carries `cvm oversized-transfer` frames.

- **Frame Types**  
  Fully implemented:
  - `start`
  - `accept`
  - `chunk`
  - `end`
  - `abort`

- **Completion Mode**  
  Render-only reconstruction path.

- **Validation Guarantees**
  - Sequence correctness
  - Completeness
  - Byte length verification
  - SHA-256 digest verification
  - JSON-RPC schema validation

- **Bootstrap Support**  
  Stateless `start → accept` handshake supported.

- **Safety Controls**
  - Configurable max bytes
  - Max chunks
  - Concurrency limits
  - Timeouts
  - Cleanup on abort/timeout

---

## Backward Compatibility

- No breaking API changes
- Peers without `support_oversized_transfer` continue using the existing non-fragmented path
- Oversized transfer remains gated by:
  - `progressToken`
  - Capability signaling

---

## Risk Notes

- **Memory / DoS Risk**  
  Mitigated via strict receiver policy limits and transfer timeouts

- **Ordering / Replay Issues**  
  Handled via:
  - Progress-based validation
  - Duplicate/conflict detection

- **Test Flakiness**  
  - Observed in encryption timeout tests under full-suite load  
  - Isolated encryption tests pass  
  - Likely environment/timing sensitivity, not deterministic regression  

---

## Test Evidence
bun run typecheck → pass
bun run lint → pass

bun test src/transport → 143 pass, 0 fail
bun test src/transport/oversized-transfer src/transport/nostr-transport-oversized-transfer.test.ts → 9 pass, 0 fail
bun test src/transport/nostr-transport-encryption.test.ts → 11 pass, 0 fail

bun test src → 214 pass, 4 fail
(failures limited to timeout-only encryption tests under full-suite load)


---

## Additional Tests Added

- `sender.test.ts`
- `receiver.test.ts`
- `nostr-transport-oversized-transfer.test.ts`
