### PR TITLE
feat(transport): ensure CEP-15 schemaHash consistency in announcement…

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,4 @@ export * from './interfaces.js';
 export * from './utils/websocket.js';
 export * from './utils/serializers.js';
 export * from './encryption.js';
+export * from './utils/canonical-schema.js';

--- a/src/core/utils/canonical-schema.test.ts
+++ b/src/core/utils/canonical-schema.test.ts
@@ -1,0 +1,227 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  canonicalizeToolInputSchema,
+  enrichToolsWithSchemaHash,
+  computeSchemaHash,
+} from './canonical-schema.js';
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+describe('canonical-schema', () => {
+  describe('canonicalizeToolInputSchema', () => {
+    test('produces deterministic output regardless of key order', () => {
+      const tool1: Tool = {
+        name: 'test-tool',
+        description: 'A test tool',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            b: { type: 'number' },
+            a: { type: 'string' },
+          },
+          required: ['a', 'b'],
+        },
+      };
+
+      const tool2: Tool = {
+        name: 'test-tool',
+        description: 'A test tool',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            a: { type: 'string' },
+            b: { type: 'number' },
+          },
+          required: ['a', 'b'],
+        },
+      };
+
+      // Different property order in source should produce same canonical output
+      expect(canonicalizeToolInputSchema(tool1)).toBe(
+        canonicalizeToolInputSchema(tool2),
+      );
+    });
+
+    test('canonicalizes nested objects correctly', () => {
+      const tool: Tool = {
+        name: 'nested-tool',
+        description: 'Tool with nested schema',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            user: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'number' },
+              },
+            },
+          },
+        },
+      };
+
+      const canonical = canonicalizeToolInputSchema(tool);
+      expect(canonical).toContain(
+        '"user":{"properties":{"age":{"type":"number"},"name":{"type":"string"}}',
+      );
+    });
+  });
+
+  describe('computeSchemaHash', () => {
+    test('produces consistent 64-character hex hash', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+        },
+      };
+
+      const hash1 = await computeSchemaHash(JSON.stringify(schema));
+      const hash2 = await computeSchemaHash(JSON.stringify(schema));
+
+      expect(hash1).toBe(hash2);
+      expect(hash1).toHaveLength(64);
+      expect(hash1).toMatch(/^[0-9a-f]+$/);
+    });
+
+    test('different schemas produce different hashes', async () => {
+      const schema1 = { type: 'object', properties: { a: { type: 'string' } } };
+      const schema2 = { type: 'object', properties: { a: { type: 'number' } } };
+
+      const hash1 = await computeSchemaHash(JSON.stringify(schema1));
+      const hash2 = await computeSchemaHash(JSON.stringify(schema2));
+
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe('enrichToolsWithSchemaHash', () => {
+    test('adds schemaHash metadata to each tool', async () => {
+      const result = {
+        tools: [
+          {
+            name: 'add',
+            description: 'Add two numbers',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+              required: ['a', 'b'],
+            },
+          },
+          {
+            name: 'subtract',
+            description: 'Subtract two numbers',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+              required: ['a', 'b'],
+            },
+          },
+        ],
+      };
+
+      const enriched = await enrichToolsWithSchemaHash(result);
+
+      expect(enriched.tools).toHaveLength(2);
+
+      // Verify schemaHash exists and is valid
+      for (const tool of enriched.tools) {
+        expect(tool._meta).toBeDefined();
+        expect(tool._meta!['io.contextvm/common-schema']).toBeDefined();
+        expect(
+          typeof tool._meta!['io.contextvm/common-schema'].schemaHash,
+        ).toBe('string');
+        expect(
+          tool._meta!['io.contextvm/common-schema'].schemaHash,
+        ).toHaveLength(64);
+      }
+    });
+
+    test('produces consistent hashes across multiple calls', async () => {
+      const result = {
+        tools: [
+          {
+            name: 'add',
+            description: 'Add two numbers',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+            },
+          },
+        ],
+      };
+
+      const enriched1 = await enrichToolsWithSchemaHash(result);
+      const enriched2 = await enrichToolsWithSchemaHash(result);
+
+      expect(
+        enriched1.tools[0]._meta!['io.contextvm/common-schema'].schemaHash,
+      ).toBe(
+        enriched2.tools[0]._meta!['io.contextvm/common-schema'].schemaHash,
+      );
+    });
+
+    test('tools with same inputSchema have same schemaHash', async () => {
+      const sameSchema = {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+        },
+      };
+
+      const result = {
+        tools: [
+          {
+            name: 'search-provider-a',
+            description: 'Search using Provider A',
+            inputSchema: sameSchema,
+          },
+          {
+            name: 'search-provider-b',
+            description: 'Search using Provider B',
+            inputSchema: sameSchema,
+          },
+        ],
+      };
+
+      const enriched = await enrichToolsWithSchemaHash(result);
+
+      // Same inputSchema = same schemaHash (interoperability!)
+      expect(
+        enriched.tools[0]._meta!['io.contextvm/common-schema'].schemaHash,
+      ).toBe(
+        enriched.tools[1]._meta!['io.contextvm/common-schema'].schemaHash,
+      );
+    });
+
+    test('preserves existing _meta fields', async () => {
+      const result = {
+        tools: [
+          {
+            name: 'tool',
+            description: 'A tool',
+            inputSchema: { type: 'object', properties: {} },
+            _meta: {
+              existingField: 'value',
+            },
+          },
+        ],
+      };
+
+      const enriched = await enrichToolsWithSchemaHash(result);
+
+      expect(enriched.tools[0]._meta!.existingField).toBe('value');
+      expect(
+        enriched.tools[0]._meta!['io.contextvm/common-schema'],
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/core/utils/canonical-schema.ts
+++ b/src/core/utils/canonical-schema.ts
@@ -1,0 +1,136 @@
+import {
+  ListToolsResult,
+  ListToolsResultSchema,
+  Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * RFC 8785 JSON Canonicalization Scheme (JCS) implementation.
+ * Produces deterministic JSON string for hashing.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (typeof value === 'number') {
+    // Handle special cases per RFC 8785
+    if (Number.isNaN(value)) {
+      throw new Error('NaN cannot be canonicalized per RFC 8785');
+    }
+    if (value === Infinity || value === -Infinity) {
+      throw new Error('Infinity cannot be canonicalized per RFC 8785');
+    }
+    // Use JSON's number serialization (IEEE 754 double-precision)
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === 'string') {
+    // JSON.stringify handles proper escaping
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    const elements = value.map((item) => canonicalize(item)).join(',');
+    return `[${elements}]`;
+  }
+
+  if (typeof value === 'object') {
+    // Sort keys lexicographically per RFC 8785
+    const keys = Object.keys(value).sort();
+    const pairs = keys.map((key) => {
+      const canonicalKey = JSON.stringify(key);
+      const canonicalValue = canonicalize((value as Record<string, unknown>)[key]);
+      return `${canonicalKey}:${canonicalValue}`;
+    });
+    return `{${pairs.join(',')}}`;
+  }
+
+  throw new Error(`Cannot canonicalize value of type ${typeof value}`);
+}
+
+/**
+ * Computes SHA-256 hash of a canonicalized schema string.
+ * Returns lowercase hex string (64 characters).
+ */
+async function computeSchemaHash(canonicalSchema: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(canonicalSchema);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Canonicalizes a tool's inputSchema using RFC 8785 JCS.
+ * Returns the canonical JSON string (suitable for hashing or comparison).
+ */
+export function canonicalizeToolInputSchema(tool: Tool): string {
+  return canonicalize(tool.inputSchema);
+}
+
+/**
+ * Enriches a tools/list result with schemaHash metadata for each tool.
+ *
+ * Adds _meta["io.contextvm/common-schema"].schemaHash to each tool definition,
+ * computed from the canonicalized inputSchema per RFC 8785 JCS.
+ *
+ * @param result - The tools/list result to enrich
+ * @returns New result with schemaHash metadata added (does not mutate input)
+ */
+export async function enrichToolsWithSchemaHash(
+  result: ListToolsResult,
+): Promise<ListToolsResult> {
+  const enrichedTools = await Promise.all(
+    result.tools.map(async (tool) => {
+      const canonicalSchema = canonicalizeToolInputSchema(tool);
+      const schemaHash = await computeSchemaHash(canonicalSchema);
+
+      return {
+        ...tool,
+        _meta: {
+          ...tool._meta,
+          'io.contextvm/common-schema': {
+            schemaHash,
+          },
+        },
+      };
+    }),
+  );
+
+  return {
+    ...result,
+    tools: enrichedTools,
+  };
+}
+
+/**
+ * Synchronous version of enrichToolsWithSchemaHash for non-async contexts.
+ * Requires pre-computed hash values.
+ */
+export function enrichToolsWithSchemaHashSync(
+  result: ListToolsResult,
+  computeHash: (tool: Tool) => string,
+): ListToolsResult {
+  const enrichedTools = result.tools.map((tool) => {
+    const schemaHash = computeHash(tool);
+    return {
+      ...tool,
+      _meta: {
+        ...tool._meta,
+        'io.contextvm/common-schema': {
+          schemaHash,
+        },
+      },
+    };
+  });
+
+  return {
+    ...result,
+    tools: enrichedTools,
+  };
+}

--- a/src/transport/nostr-server/announcement-manager.test.ts
+++ b/src/transport/nostr-server/announcement-manager.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect } from 'bun:test';
+import { AnnouncementManager } from './announcement-manager.js';
+import { EncryptionMode, GiftWrapMode } from '../../core/interfaces.js';
+
+describe('AnnouncementManager', () => {
+  describe('CEP-15 schemaHash enrichment', () => {
+    test('publishAnnouncementEvent enriches tools/list with schemaHash', async () => {
+      const publishedEvents: any[] = [];
+
+      const manager = new AnnouncementManager({
+        encryptionMode: EncryptionMode.OPTIONAL,
+        giftWrapMode: GiftWrapMode.OPTIONAL,
+        onDispatchMessage: () => {},
+        onPublishEvent: async (event) => publishedEvents.push(event),
+        onSignEvent: async (template) => ({
+          ...template,
+          id: 'mock-event-id',
+          sig: 'mock-sig',
+        }),
+        onGetPublicKey: async () => 'mock-pubkey',
+        onSubscribe: async () => {},
+        logger: {
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+          debug: () => {},
+        },
+      });
+
+      const toolsListResult = {
+        tools: [
+          {
+            name: 'add',
+            description: 'Add two numbers',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+            },
+          },
+        ],
+      };
+
+      // Access private method via any cast for testing
+      await (manager as any).publishAnnouncementEvent(toolsListResult);
+
+      expect(publishedEvents.length).toBeGreaterThan(0);
+      const publishedEvent = publishedEvents.find(
+        (e) => e.kind === 11317,
+      ); // TOOLS_LIST_KIND
+
+      expect(publishedEvent).toBeDefined();
+
+      const content = JSON.parse(publishedEvent.content);
+      expect(
+        content.tools[0]._meta['io.contextvm/common-schema'].schemaHash,
+      ).toBeDefined();
+      expect(
+        content.tools[0]._meta['io.contextvm/common-schema'].schemaHash,
+      ).toHaveLength(64);
+    });
+
+    test('schemaHash is consistent between multiple enrichments', async () => {
+      const publishedEvents: any[] = [];
+
+      const manager = new AnnouncementManager({
+        encryptionMode: EncryptionMode.OPTIONAL,
+        giftWrapMode: GiftWrapMode.OPTIONAL,
+        onDispatchMessage: () => {},
+        onPublishEvent: async (event) => publishedEvents.push(event),
+        onSignEvent: async (template) => ({
+          ...template,
+          id: 'mock-event-id',
+          sig: 'mock-sig',
+        }),
+        onGetPublicKey: async () => 'mock-pubkey',
+        onSubscribe: async () => {},
+        logger: {
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+          debug: () => {},
+        },
+      });
+
+      const toolsListResult = {
+        tools: [
+          {
+            name: 'add',
+            description: 'Add two numbers',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: { type: 'number' },
+                b: { type: 'number' },
+              },
+            },
+          },
+        ],
+      };
+
+      await (manager as any).publishAnnouncementEvent(toolsListResult);
+      await (manager as any).publishAnnouncementEvent(toolsListResult);
+
+      const event1 = publishedEvents[0];
+      const event2 = publishedEvents[1];
+
+      const content1 = JSON.parse(event1.content);
+      const content2 = JSON.parse(event2.content);
+
+      // Same input schema should produce identical schemaHash
+      expect(
+        content1.tools[0]._meta['io.contextvm/common-schema'].schemaHash,
+      ).toBe(
+        content2.tools[0]._meta['io.contextvm/common-schema'].schemaHash,
+      );
+    });
+
+    test('non-tools/list results are not modified', async () => {
+      const publishedEvents: any[] = [];
+
+      const manager = new AnnouncementManager({
+        encryptionMode: EncryptionMode.OPTIONAL,
+        giftWrapMode: GiftWrapMode.OPTIONAL,
+        onDispatchMessage: () => {},
+        onPublishEvent: async (event) => publishedEvents.push(event),
+        onSignEvent: async (template) => ({
+          ...template,
+          id: 'mock-event-id',
+          sig: 'mock-sig',
+        }),
+        onGetPublicKey: async () => 'mock-pubkey',
+        onSubscribe: async () => {},
+        logger: {
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+          debug: () => {},
+        },
+      });
+
+      const resourcesListResult = {
+        resources: [
+          {
+            uri: 'resource://test',
+            name: 'Test Resource',
+          },
+        ],
+      };
+
+      await (manager as any).publishAnnouncementEvent(resourcesListResult);
+
+      const publishedEvent = publishedEvents.find(
+        (e) => e.kind === 11318,
+      ); // RESOURCES_LIST_KIND
+
+      expect(publishedEvent).toBeDefined();
+
+      const content = JSON.parse(publishedEvent.content);
+      // Resources should not have _meta injected
+      expect(content.resources[0]._meta).toBeUndefined();
+    });
+  });
+});

--- a/src/transport/nostr-server/announcement-manager.ts
+++ b/src/transport/nostr-server/announcement-manager.ts
@@ -11,11 +11,13 @@ import {
   ListPromptsResultSchema,
   ListResourcesResultSchema,
   ListResourceTemplatesResultSchema,
+  ListToolsResult,
   ListToolsResultSchema,
   type JSONRPCMessage,
   type JSONRPCResponse,
   isJSONRPCResultResponse,
 } from '@modelcontextprotocol/sdk/types.js';
+import { enrichToolsWithSchemaHash } from '../../core/utils/canonical-schema.js';
 import type { Filter } from 'nostr-tools';
 import { NostrEvent } from 'nostr-tools';
 import { EventDeletion } from 'nostr-tools/kinds';
@@ -497,9 +499,15 @@ export class AnnouncementManager {
 
       for (const mapping of announcementMapping) {
         if (mapping.schema.safeParse(result).success) {
+          // Enrich tools/list results with schemaHash for CEP-15 consistency
+          const enrichedResult =
+            ListToolsResultSchema.safeParse(result).success
+              ? await enrichToolsWithSchemaHash(result as ListToolsResult)
+              : result;
+
           const eventTemplate = {
             kind: mapping.kind,
-            content: JSON.stringify(result),
+            content: JSON.stringify(enrichedResult),
             tags: mapping.tags,
             created_at: Math.floor(Date.now() / 1000),
             pubkey: recipientPubkey,


### PR DESCRIPTION
## CEP-15: Ensure schemaHash consistency in announcement events (kind:11317)

### Problem

CEP-15 uses schemaHash so clients can recognize when two tools are actually the same across different providers. For that to work, the hash has to be consistent no matter how the tool is discovered.

Right now, direct `tools/list` responses already include `schemaHash` (from PR #38), but announcement events (`kind:11317`) don’t. That means a client discovering a tool via relay announcements won’t see the same metadata as when it fetches the tool directly. As a result, it can’t reliably match or deduplicate tools across providers, which defeats the purpose of `schema-based` interoperability.

### Solution

This PR fixes that gap by making announcement events consistent with direct responses. Inside `publishAnnouncementEvent()`, it reuses the existing helper from PR #37 to enrich `tools/list` results with schemaHash before serializing them. A schema check ensures this only applies to `tools/list` payloads, so other announcement types remain unchanged.

### Why this matters

After this change, both discovery paths produce the same `schemaHash`, so clients can reliably compare tools regardless of how they were discovered. This makes CEP-15 actually usable in practice, enabling proper deduplication and smoother provider switching.