### PR TITLE
feat(transport): add server profile metadata publication (CEP-23)

### DIFF
--- a/.changeset/spotty-comics-relate.md
+++ b/.changeset/spotty-comics-relate.md
@@ -1,5 +1,5 @@
 ---
-"@contextvm/sdk": patch
+"@contextvm/sdk": minor
 ---
 
 feat(transport): add optional NIP-01 kind:0 profile metadata publication (CEP-23) for `NostrServerTransport`.

--- a/.changeset/spotty-comics-relate.md
+++ b/.changeset/spotty-comics-relate.md
@@ -1,0 +1,7 @@
+---
+"@contextvm/sdk": patch
+---
+
+feat(transport): add optional NIP-01 kind:0 profile metadata publication (CEP-23) for `NostrServerTransport`.
+
+Also improves discoverability relay publication behavior in local/non-websocket relay environments and stabilizes related transport tests.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run tests
         env:
           NODE_ENV: test
-        run: bun test --concurrent --timeout=60000
+        run: bun test --timeout=60000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run tests
         env:
           NODE_ENV: test
-        run: bun test --timeout=60000
+        run: bun test --concurrent --timeout=60000

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -52,6 +52,12 @@ export const PROMPTS_LIST_KIND = 11320;
 export const RELAY_LIST_METADATA_KIND = 10002;
 
 /**
+ * NIP-01 profile metadata event kind.
+ * Used for optional server identity publication (CEP-23).
+ */
+export const PROFILE_METADATA_KIND = 0;
+
+/**
  * Default relay targets for discoverability publication.
  *
  * These relays are used as additional publication targets for server metadata,

--- a/src/transport/nostr-server-transport.test.ts
+++ b/src/transport/nostr-server-transport.test.ts
@@ -370,7 +370,6 @@ describe.serial('NostrServerTransport', () => {
         name: 'Private Profile Server',
         about: 'Publishes kind 0 without public announcements',
         website: 'https://example.com/private-server',
-        contextvm: true,
       };
 
       const server = new McpServer({
@@ -382,6 +381,7 @@ describe.serial('NostrServerTransport', () => {
         signer: new PrivateKeySigner(serverPrivateKey),
         relayHandler: new ApplesauceRelayPool([relayUrl]),
         profileMetadata,
+        bootstrapRelayUrls: [],
       });
 
       await server.connect(transport);

--- a/src/transport/nostr-server-transport.test.ts
+++ b/src/transport/nostr-server-transport.test.ts
@@ -18,6 +18,7 @@ import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
 import {
   CTXVM_MESSAGES_KIND,
   INITIALIZE_METHOD,
+  PROFILE_METADATA_KIND,
   PROMPTS_LIST_KIND,
   RELAY_LIST_METADATA_KIND,
   RESOURCES_LIST_KIND,
@@ -341,6 +342,65 @@ describe.serial('NostrServerTransport', () => {
 
       expect(relayListEvent.kind).toBe(RELAY_LIST_METADATA_KIND);
       expect(relayListEvent.tags).toEqual([['r', relayUrl]]);
+
+      await expect(
+        waitForNostrEvent({
+          relayPool,
+          filters: [
+            { kinds: [SERVER_ANNOUNCEMENT_KIND], authors: [serverPublicKey] },
+          ],
+          where: () => true,
+          timeoutMs: 750,
+        }),
+      ).rejects.toThrow('Timed out waiting for matching Nostr event');
+
+      await server.close();
+      await relayPool.disconnect();
+    },
+    10000,
+  );
+
+  test.serial(
+    'should publish profile metadata when configured even if server is not announced',
+    async () => {
+      const serverPrivateKey = bytesToHex(generateSecretKey());
+      const serverPublicKey = getPublicKey(hexToBytes(serverPrivateKey));
+
+      const profileMetadata = {
+        name: 'Private Profile Server',
+        about: 'Publishes kind 0 without public announcements',
+        website: 'https://example.com/private-server',
+        contextvm: true,
+      };
+
+      const server = new McpServer({
+        name: 'Profile Metadata Server',
+        version: '1.0.0',
+      });
+
+      const transport = new NostrServerTransport({
+        signer: new PrivateKeySigner(serverPrivateKey),
+        relayHandler: new ApplesauceRelayPool([relayUrl]),
+        profileMetadata,
+      });
+
+      await server.connect(transport);
+
+      const relayPool = new ApplesauceRelayPool([relayUrl]);
+      await relayPool.connect();
+
+      const profileEvent = await waitForNostrEvent({
+        relayPool,
+        filters: [
+          { kinds: [PROFILE_METADATA_KIND], authors: [serverPublicKey] },
+        ],
+        where: () => true,
+      });
+
+      expect(profileEvent.kind).toBe(PROFILE_METADATA_KIND);
+      expect(profileEvent.pubkey).toBe(serverPublicKey);
+      expect(profileEvent.tags).toEqual([]);
+      expect(JSON.parse(profileEvent.content)).toEqual(profileMetadata);
 
       await expect(
         waitForNostrEvent({

--- a/src/transport/nostr-server-transport.ts
+++ b/src/transport/nostr-server-transport.ts
@@ -42,8 +42,8 @@ import {
 } from './nostr-server/authorization-policy.js';
 import {
   AnnouncementManager,
-  ProfileMetadata,
-  ServerInfo,
+  type ProfileMetadata,
+  type ServerInfo,
 } from './nostr-server/announcement-manager.js';
 import type { RelayHandler } from '../core/interfaces.js';
 import {

--- a/src/transport/nostr-server-transport.ts
+++ b/src/transport/nostr-server-transport.ts
@@ -353,6 +353,8 @@ export class NostrServerTransport
 
       if (this.authorizationPolicy.isAnnouncedServer) {
         await this.announcementManager.publishPublicAnnouncements();
+      } else {
+        await this.announcementManager.publishProfileMetadata();
       }
 
       await this.announcementManager.publishRelayList();

--- a/src/transport/nostr-server-transport.ts
+++ b/src/transport/nostr-server-transport.ts
@@ -353,9 +353,9 @@ export class NostrServerTransport
 
       if (this.authorizationPolicy.isAnnouncedServer) {
         await this.announcementManager.publishPublicAnnouncements();
-      } else {
-        await this.announcementManager.publishProfileMetadata();
       }
+
+      await this.announcementManager.publishProfileMetadata();
 
       await this.announcementManager.publishRelayList();
     } catch (error) {

--- a/src/transport/nostr-server-transport.ts
+++ b/src/transport/nostr-server-transport.ts
@@ -42,6 +42,7 @@ import {
 } from './nostr-server/authorization-policy.js';
 import {
   AnnouncementManager,
+  ProfileMetadata,
   ServerInfo,
 } from './nostr-server/announcement-manager.js';
 import type { RelayHandler } from '../core/interfaces.js';
@@ -62,6 +63,8 @@ import {
  */
 export interface NostrServerTransportOptions extends BaseNostrTransportOptions {
   serverInfo?: ServerInfo;
+  /** Optional NIP-01 kind:0 profile metadata for server identity (CEP-23). Opt-in. */
+  profileMetadata?: ProfileMetadata;
   /**
    * @deprecated Use `isAnnouncedServer` instead. `isPublicServer` will be removed in a future version.
    */
@@ -254,6 +257,7 @@ export class NostrServerTransport
     // Initialize announcement manager
     this.announcementManager = new AnnouncementManager({
       serverInfo: options.serverInfo,
+      profileMetadata: options.profileMetadata,
       encryptionMode: this.encryptionMode,
       giftWrapMode: this.giftWrapMode,
       extraCommonTags: [],

--- a/src/transport/nostr-server/announcement-manager.test.ts
+++ b/src/transport/nostr-server/announcement-manager.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import type { Filter, NostrEvent } from 'nostr-tools';
+import { PROFILE_METADATA_KIND } from '../../core/constants.js';
 import { EncryptionMode, GiftWrapMode } from '../../core/interfaces.js';
 import {
   AnnouncementManager,
   type AnnouncementManagerOptions,
+  type ProfileMetadata,
 } from './announcement-manager.js';
 
 const createBaseOptions = (
@@ -20,10 +22,8 @@ const createBaseOptions = (
       sig: 'signed-event-sig',
     }) as NostrEvent,
   onGetPublicKey: async () => 'server-pubkey',
-  onSubscribe: async (
-    _filters: Filter[],
-    _onEvent: (event: NostrEvent) => void,
-  ) => undefined,
+  onSubscribe: async (_filters: Filter[], _onEvent: (event: NostrEvent) => void) =>
+    undefined,
   logger: {
     info: () => undefined,
     warn: () => undefined,
@@ -33,7 +33,7 @@ const createBaseOptions = (
   ...overrides,
 });
 
-describe('AnnouncementManager relay publication', () => {
+describe('AnnouncementManager profile metadata publication', () => {
   test('publishRelayList() does not append default bootstrap relays for local operational relays', async () => {
     let publishedRelayUrls: string[] | undefined;
 
@@ -92,5 +92,162 @@ describe('AnnouncementManager relay publication', () => {
 
     expect(publishEventCalled).toBe(true);
     expect(publishEventToRelaysCalled).toBe(false);
+  });
+
+  test('publishProfileMetadata() produces a valid kind:0 event', async () => {
+    const profileMetadata: ProfileMetadata = {
+      name: 'ContextVM Server',
+      about: 'A public MCP server',
+      website: 'https://contextvm.org',
+      picture: 'https://example.com/avatar.png',
+    };
+
+    let signedTemplate: NostrEvent | undefined;
+    let publishedEvent: NostrEvent | undefined;
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        profileMetadata,
+        onSignEvent: async (eventTemplate) => {
+          signedTemplate = eventTemplate;
+          return {
+            ...eventTemplate,
+            id: 'profile-event-id',
+            sig: 'profile-event-sig',
+          } as NostrEvent;
+        },
+        onPublishEvent: async (event) => {
+          publishedEvent = event;
+        },
+      }),
+    );
+
+    await manager.publishProfileMetadata();
+
+    expect(signedTemplate).toBeDefined();
+    expect(signedTemplate!.kind).toBe(PROFILE_METADATA_KIND);
+    expect(signedTemplate!.pubkey).toBe('server-pubkey');
+    expect(signedTemplate!.tags).toEqual([]);
+    expect(signedTemplate!.content).toBe(JSON.stringify(profileMetadata));
+
+    expect(publishedEvent).toBeDefined();
+    expect(publishedEvent!.kind).toBe(PROFILE_METADATA_KIND);
+  });
+
+  test('publishProfileMetadata() skips publication when profileMetadata is not configured', async () => {
+    let signCalled = false;
+    let publishCalled = false;
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        onSignEvent: async (eventTemplate) => {
+          signCalled = true;
+          return {
+            ...eventTemplate,
+            id: 'unexpected-sign-id',
+            sig: 'unexpected-sign-sig',
+          } as NostrEvent;
+        },
+        onPublishEvent: async () => {
+          publishCalled = true;
+        },
+      }),
+    );
+
+    await manager.publishProfileMetadata();
+
+    expect(signCalled).toBe(false);
+    expect(publishCalled).toBe(false);
+  });
+
+  test('publishProfileMetadata() preserves all optional and custom fields through JSON serialization', async () => {
+    const profileMetadata: ProfileMetadata = {
+      name: 'Profile Name',
+      about: 'Profile About',
+      picture: 'https://example.com/picture.png',
+      banner: 'https://example.com/banner.png',
+      website: 'https://example.com',
+      nip05: 'server@example.com',
+      lud16: 'tips@getalby.com',
+      custom_flag: true,
+      changelog_url: 'https://example.com/changelog',
+    };
+
+    let serializedContent = '';
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        profileMetadata,
+        onSignEvent: async (eventTemplate) => {
+          serializedContent = eventTemplate.content;
+          return {
+            ...eventTemplate,
+            id: 'roundtrip-event-id',
+            sig: 'roundtrip-event-sig',
+          } as NostrEvent;
+        },
+      }),
+    );
+
+    await manager.publishProfileMetadata();
+
+    expect(JSON.parse(serializedContent)).toEqual(profileMetadata);
+  });
+
+  test('publishPublicAnnouncements() only requests announcement publication', async () => {
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        profileMetadata: { name: 'Sequenced Profile' },
+      }),
+    );
+
+    let requestCalled = false;
+    let profileCalled = false;
+
+    (manager as unknown as { requestAnnouncementPublication: () => Promise<void> }).requestAnnouncementPublication =
+      async () => {
+        requestCalled = true;
+      };
+
+    manager.publishProfileMetadata = async () => {
+      profileCalled = true;
+    };
+
+    await manager.publishPublicAnnouncements();
+
+    expect(requestCalled).toBe(true);
+    expect(profileCalled).toBe(false);
+  });
+
+  test('publishProfileMetadata() logs publication errors and does not throw', async () => {
+    const loggedErrors: Array<{ message: string; meta?: unknown }> = [];
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        profileMetadata: { name: 'Failure Case Profile' },
+        onSignEvent: async () => {
+          throw new Error('sign failure');
+        },
+        logger: {
+          info: () => undefined,
+          warn: () => undefined,
+          debug: () => undefined,
+          error: (message, meta) => {
+            loggedErrors.push({ message, meta });
+          },
+        },
+      }),
+    );
+
+    let threw = false;
+    try {
+      await manager.publishProfileMetadata();
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(loggedErrors.length).toBe(1);
+    expect(loggedErrors[0]!.message).toBe('Error publishing profile metadata');
   });
 });

--- a/src/transport/nostr-server/announcement-manager.ts
+++ b/src/transport/nostr-server/announcement-manager.ts
@@ -425,7 +425,6 @@ export class AnnouncementManager {
    */
   public async publishPublicAnnouncements(): Promise<void> {
     await this.requestAnnouncementPublication();
-    await this.publishProfileMetadata();
   }
 
   /**

--- a/src/transport/nostr-server/announcement-manager.ts
+++ b/src/transport/nostr-server/announcement-manager.ts
@@ -29,6 +29,7 @@ import {
   RESOURCETEMPLATES_LIST_KIND,
   PROMPTS_LIST_KIND,
   RELAY_LIST_METADATA_KIND,
+  PROFILE_METADATA_KIND,
   NOSTR_TAGS,
   INITIALIZE_METHOD,
   NOTIFICATIONS_INITIALIZED_METHOD,
@@ -47,11 +48,32 @@ export interface ServerInfo {
 }
 
 /**
+ * Optional NIP-01 kind:0 profile metadata for server identity.
+ * When provided, the server publishes a kind:0 event at startup
+ * to establish a social presence on Nostr.
+ *
+ * This is separate from ServerInfo - not all servers want a social profile.
+ * kind:0 events are rendered by social Nostr clients.
+ */
+export interface ProfileMetadata {
+  name?: string;
+  about?: string;
+  picture?: string;
+  banner?: string;
+  website?: string;
+  nip05?: string;
+  lud16?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Options for configuring the AnnouncementManager.
  */
 export interface AnnouncementManagerOptions {
   /** Server information to include in announcements */
   serverInfo?: ServerInfo;
+  /** Optional kind:0 profile metadata. When provided, publishes a kind:0 event at startup. */
+  profileMetadata?: ProfileMetadata;
   /** Encryption mode for determining tag inclusion */
   encryptionMode: EncryptionMode;
 
@@ -120,6 +142,7 @@ interface AnnouncementMapping {
  */
 export class AnnouncementManager {
   private readonly serverInfo?: ServerInfo;
+  private readonly profileMetadata?: ProfileMetadata;
   private readonly encryptionMode: EncryptionMode;
   private readonly giftWrapMode: GiftWrapMode;
   private extraCommonTags: string[][];
@@ -152,6 +175,7 @@ export class AnnouncementManager {
 
   constructor(options: AnnouncementManagerOptions) {
     this.serverInfo = options.serverInfo;
+    this.profileMetadata = options.profileMetadata;
     this.encryptionMode = options.encryptionMode;
     this.giftWrapMode = options.giftWrapMode;
     this.extraCommonTags = options.extraCommonTags ?? [];
@@ -207,6 +231,39 @@ export class AnnouncementManager {
       });
     } catch (error) {
       this.logger.error('Error publishing relay list metadata', {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
+  }
+
+  /**
+   * Publishes NIP-01 kind:0 profile metadata when configured.
+   * This creates a social identity for the server on Nostr.
+   */
+  public async publishProfileMetadata(): Promise<void> {
+    if (!this.profileMetadata) {
+      return;
+    }
+
+    try {
+      const publicKey = await this.onGetPublicKey();
+      const content = JSON.stringify(this.profileMetadata);
+      const eventTemplate = {
+        kind: PROFILE_METADATA_KIND,
+        content,
+        tags: [] as string[][],
+        created_at: Math.floor(Date.now() / 1000),
+        pubkey: publicKey,
+      };
+
+      const signedEvent = await this.onSignEvent(eventTemplate as NostrEvent);
+      await this.publishDiscoverabilityEvent(signedEvent);
+      this.logger.debug('Published profile metadata event', {
+        eventId: signedEvent.id,
+      });
+    } catch (error) {
+      this.logger.error('Error publishing profile metadata', {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
       });
@@ -368,6 +425,7 @@ export class AnnouncementManager {
    */
   public async publishPublicAnnouncements(): Promise<void> {
     await this.requestAnnouncementPublication();
+    await this.publishProfileMetadata();
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR adds opt-in server profile metadata publication using NIP-01 kind 0 events (CEP-23) in the SDK server transport path. It also includes a startup-flow fix so profile metadata can publish even when public announcements are disabled, plus targeted regression coverage.

## Problem

- Servers can advertise capabilities and relay metadata, but cannot publish a standard social identity profile.
- Capability announcements are not a substitute for profile identity rendering in Nostr clients.
- Profile publication should remain optional, because not every server wants social presence.
- A startup coupling issue could silently skip profile publication for private/non-announced servers.

## Design

- Added a dedicated profile metadata kind constant.
- Introduced a typed profile metadata option on transport and announcement layers.
- Implemented signed kind 0 event publication using existing discoverability publishing infrastructure.
- Wired profile publication into startup behavior for both modes:
  - **Announced server:** publish announcements and profile metadata.
  - **Non-announced server:** publish profile metadata only when configured.
- Preserved existing relay-list and discoverability behavior.
- Kept API additive and fully opt-in.

## Key Files

- `constants.ts`
- `announcement-manager.ts`
- `nostr-server-transport.ts`
- `announcement-manager.test.ts`
- `nostr-server-transport.test.ts`

## Test Evidence

- **New unit tests validate:**
  - `kind 0` event shape and serialization
  - no-op behavior when profile metadata is omitted
  - error logging without throwing
  - public-announcement sequencing
- **New integration test validates:**
  - profile metadata publishes for non-announced/private servers
  - server announcement events are still not published in that mode
- **Full SDK validation:**
  - `bun test src`: 239 pass, 5 skipped, 0 fail
  - `bun run build`: success

---

Addresses backend implementation for [ContextVM/contextvm-docs#23](https://github.com/ContextVM/contextvm-docs/issues/23)
