### PR TITLE
feat(transport): simplify NostrSigner initialization to accept hex string

### DIFF
--- a/src/transport/base-nostr-transport.test.ts
+++ b/src/transport/base-nostr-transport.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'bun:test';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { bytesToHex } from 'nostr-tools/utils';
+import { NostrServerTransport } from './nostr-server-transport.js';
+import { NostrClientTransport } from './nostr-client-transport.js';
+import { PrivateKeySigner } from '../signer/private-key-signer.js';
+
+describe('BaseNostrTransport signer shorthand', () => {
+  const privateKey = generateSecretKey();
+  const privateKeyHex = bytesToHex(privateKey);
+  const expectedPublicKey = getPublicKey(privateKey);
+
+  test('NostrServerTransport accepts a hex string signer', async () => {
+    const transport = new NostrServerTransport({
+      signer: privateKeyHex,
+      relayHandler: ['wss://unused.example.com'],
+    });
+
+    // Constructing without errors validates the instantiation.
+    await expect(transport.close()).resolves.toBeUndefined();
+  });
+
+  test('NostrServerTransport accepts a NostrSigner instance', async () => {
+    const signer = new PrivateKeySigner(privateKeyHex);
+    const transport = new NostrServerTransport({
+      signer,
+      relayHandler: ['wss://unused.example.com'],
+    });
+
+    await expect(transport.close()).resolves.toBeUndefined();
+  });
+
+  test('NostrClientTransport accepts a hex string signer', async () => {
+    const serverKey = bytesToHex(generateSecretKey());
+    const serverPubkey = getPublicKey(generateSecretKey());
+
+    const transport = new NostrClientTransport({
+      signer: serverKey,
+      serverPubkey,
+      relayHandler: ['wss://unused.example.com'],
+    });
+
+    await expect(transport.close()).resolves.toBeUndefined();
+  });
+
+  test('NostrClientTransport accepts a NostrSigner instance', async () => {
+    const signer = new PrivateKeySigner(privateKeyHex);
+    const serverPubkey = getPublicKey(generateSecretKey());
+
+    const transport = new NostrClientTransport({
+      signer,
+      serverPubkey,
+      relayHandler: ['wss://unused.example.com'],
+    });
+
+    await expect(transport.close()).resolves.toBeUndefined();
+  });
+
+  test('hex string signer produces correct public key', async () => {
+    const signer = new PrivateKeySigner(privateKeyHex);
+    const pubkey = await signer.getPublicKey();
+    expect(pubkey).toBe(expectedPublicKey);
+
+    const transport = new NostrServerTransport({
+      signer: privateKeyHex,
+      relayHandler: ['wss://unused.example.com'],
+    });
+
+    expect(transport).toBeDefined();
+    await transport.close();
+  });
+});

--- a/src/transport/base-nostr-transport.ts
+++ b/src/transport/base-nostr-transport.ts
@@ -29,13 +29,19 @@ import {
 } from '../core/utils/logger.js';
 import { TaskQueue } from '../core/utils/task-queue.js';
 import { ApplesauceRelayPool } from '../relay/applesauce-relay-pool.js';
+import { PrivateKeySigner } from '../signer/private-key-signer.js';
 
 /**
  * Base options for configuring Nostr-based transports.
  */
-// TODO: We could improve the ergonomics of this and simplify the signer creation, it can accept a NostrSigner instance or an string defaulting to a private key signer
 export interface BaseNostrTransportOptions {
-  signer: NostrSigner;
+  /**
+   * Signer for Nostr events.
+   *
+   * Accepts a {@link NostrSigner} instance or a hex-encoded private key string.
+   * When a string is provided, a {@link PrivateKeySigner} is created automatically.
+   */
+  signer: NostrSigner | string;
   relayHandler: RelayHandler | string[];
   encryptionMode?: EncryptionMode;
   giftWrapMode?: GiftWrapMode;
@@ -70,7 +76,9 @@ export abstract class BaseNostrTransport {
   private readonly subscriptionUnsubscribers = new Set<() => void>();
 
   constructor(module: string, options: BaseNostrTransportOptions) {
-    this.signer = options.signer;
+    this.signer = typeof options.signer === 'string'
+      ? new PrivateKeySigner(options.signer)
+      : options.signer;
     this.relayHandler = Array.isArray(options.relayHandler)
       ? new ApplesauceRelayPool(options.relayHandler)
       : options.relayHandler;


### PR DESCRIPTION
Fixes #46 

## Description
This PR addresses the TODO in `base-nostr-transport.ts` by improving the ergonomics of the `NostrSigner` initialization. It allows the `signer` option to directly accept a hex-encoded private key string as a shorthand, automatically wrapping it in a `PrivateKeySigner` internally.

This is a non-breaking, additive change. Existing code that passes a completely instantiated `NostrSigner` will continue to function exactly as before.

## Changes Made
- Updated `BaseNostrTransportOptions.signer` to accept `NostrSigner | string`.
- Added constructor logic to resolve the string into a `PrivateKeySigner`.
- Added 5 comprehensive unit tests targeting both client and server transports with `string` and `NostrSigner` inputs.

## Testing Performed
- Ran type checks (`tsc --noEmit`) - passed.
- All new and existing unit tests pass cleanly.
