### PR TITLE
fix(transport): make discoverability relay publication deterministic

### DIFF
--- a/.changeset/gentle-bats-listen.md
+++ b/.changeset/gentle-bats-listen.md
@@ -1,0 +1,9 @@
+---
+"@contextvm/sdk": patch
+---
+
+fix(transport): make discoverability relay publication deterministic for local and memory relay environments.
+
+- Skip default bootstrap relays when operational relays are local/memory and no explicit bootstrap list is configured.
+- Fallback to direct publish when discoverability targets are non-websocket relay URLs.
+- Stabilize oversized transfer event assertions and add focused announcement manager coverage for relay target selection.

--- a/src/transport/nostr-oversized-transfer.e2e.test.ts
+++ b/src/transport/nostr-oversized-transfer.e2e.test.ts
@@ -9,7 +9,7 @@ import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { bytesToHex, hexToBytes } from 'nostr-tools/utils';
 import { waitFor } from '../core/utils/test.utils.js';
 import { EncryptionMode } from '../core/interfaces.js';
-import { NOSTR_TAGS } from '../core/constants.js';
+import { CTXVM_MESSAGES_KIND, NOSTR_TAGS } from '../core/constants.js';
 import { NostrClientTransport } from './nostr-client-transport.js';
 import { NostrServerTransport } from './nostr-server-transport.js';
 import { PrivateKeySigner } from '../signer/private-key-signer.js';
@@ -408,7 +408,11 @@ describe('Nostr oversized transfer end-to-end', () => {
       produce: () => {
         const events = relayHub
           .getEvents()
-          .filter((event) => event.pubkey === serverPublicKey);
+          .filter(
+            (event) =>
+              event.pubkey === serverPublicKey &&
+              event.kind === CTXVM_MESSAGES_KIND,
+          );
         return events.length >= 2 ? events : undefined;
       },
       timeoutMs: 5_000,

--- a/src/transport/nostr-server/announcement-manager.test.ts
+++ b/src/transport/nostr-server/announcement-manager.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+import type { Filter, NostrEvent } from 'nostr-tools';
+import { EncryptionMode, GiftWrapMode } from '../../core/interfaces.js';
+import {
+  AnnouncementManager,
+  type AnnouncementManagerOptions,
+} from './announcement-manager.js';
+
+const createBaseOptions = (
+  overrides: Partial<AnnouncementManagerOptions> = {},
+): AnnouncementManagerOptions => ({
+  encryptionMode: EncryptionMode.DISABLED,
+  giftWrapMode: GiftWrapMode.PERSISTENT,
+  onDispatchMessage: () => undefined,
+  onPublishEvent: async () => undefined,
+  onSignEvent: async (eventTemplate) =>
+    ({
+      ...eventTemplate,
+      id: 'signed-event-id',
+      sig: 'signed-event-sig',
+    }) as NostrEvent,
+  onGetPublicKey: async () => 'server-pubkey',
+  onSubscribe: async (
+    _filters: Filter[],
+    _onEvent: (event: NostrEvent) => void,
+  ) => undefined,
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+  ...overrides,
+});
+
+describe('AnnouncementManager relay publication', () => {
+  test('publishRelayList() does not append default bootstrap relays for local operational relays', async () => {
+    let publishedRelayUrls: string[] | undefined;
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        onGetRelayUrls: () => ['ws://127.0.0.1:8080'],
+        onPublishEventToRelays: async (_event, relayUrls) => {
+          publishedRelayUrls = relayUrls;
+        },
+      }),
+    );
+
+    await manager.publishRelayList();
+
+    expect(publishedRelayUrls).toEqual(['ws://127.0.0.1:8080']);
+  });
+
+  test('publishRelayList() keeps explicit bootstrap relays even for local operational relays', async () => {
+    let publishedRelayUrls: string[] | undefined;
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        onGetRelayUrls: () => ['ws://127.0.0.1:8080'],
+        bootstrapRelayUrls: ['wss://bootstrap.example.com'],
+        onPublishEventToRelays: async (_event, relayUrls) => {
+          publishedRelayUrls = relayUrls;
+        },
+      }),
+    );
+
+    await manager.publishRelayList();
+
+    expect(publishedRelayUrls).toEqual([
+      'ws://127.0.0.1:8080',
+      'wss://bootstrap.example.com',
+    ]);
+  });
+
+  test('publishRelayList() falls back to onPublishEvent for non-websocket relay targets', async () => {
+    let publishEventCalled = false;
+    let publishEventToRelaysCalled = false;
+
+    const manager = new AnnouncementManager(
+      createBaseOptions({
+        relayListUrls: ['memory://relay'],
+        onPublishEvent: async () => {
+          publishEventCalled = true;
+        },
+        onPublishEventToRelays: async () => {
+          publishEventToRelaysCalled = true;
+        },
+      }),
+    );
+
+    await manager.publishRelayList();
+
+    expect(publishEventCalled).toBe(true);
+    expect(publishEventToRelaysCalled).toBe(false);
+  });
+});

--- a/src/transport/nostr-server/announcement-manager.ts
+++ b/src/transport/nostr-server/announcement-manager.ts
@@ -34,6 +34,7 @@ import {
   NOTIFICATIONS_INITIALIZED_METHOD,
 } from '../../core/index.js';
 import { EncryptionMode, GiftWrapMode } from '../../core/interfaces.js';
+import { isLocalRelayUrl, isWebsocketRelayUrl } from './utils.js';
 
 /**
  * Information about a server.
@@ -630,7 +631,7 @@ export class AnnouncementManager {
     const shouldSkipDefaultBootstrapRelayUrls =
       !this.hasExplicitBootstrapRelayUrls &&
       advertisedRelayUrls.length > 0 &&
-      advertisedRelayUrls.every((relayUrl) => this.isLocalRelayUrl(relayUrl));
+      advertisedRelayUrls.every((relayUrl) => isLocalRelayUrl(relayUrl));
 
     const bootstrapRelayUrls = shouldSkipDefaultBootstrapRelayUrls
       ? []
@@ -646,44 +647,12 @@ export class AnnouncementManager {
     return [...new Set(relayUrls.filter((relayUrl) => relayUrl.length > 0))];
   }
 
-  private isLocalRelayUrl(relayUrl: string): boolean {
-    if (relayUrl.startsWith('memory://')) {
-      return true;
-    }
-
-    let url: URL;
-    try {
-      url = new URL(relayUrl);
-    } catch {
-      return false;
-    }
-
-    const hostname = url.hostname.toLowerCase();
-    return (
-      hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
-      hostname === '::1' ||
-      hostname === '0.0.0.0'
-    );
-  }
-
-  private isWebsocketRelayUrl(relayUrl: string): boolean {
-    let url: URL;
-    try {
-      url = new URL(relayUrl);
-    } catch {
-      return false;
-    }
-
-    return url.protocol === 'ws:' || url.protocol === 'wss:';
-  }
-
   private async publishDiscoverabilityEvent(event: NostrEvent): Promise<void> {
     const relayUrls = this.getDiscoverabilityPublishRelayUrls();
     if (
       relayUrls.length &&
       this.onPublishEventToRelays &&
-      relayUrls.every((relayUrl) => this.isWebsocketRelayUrl(relayUrl))
+      relayUrls.every((relayUrl) => isWebsocketRelayUrl(relayUrl))
     ) {
       await this.onPublishEventToRelays(event, relayUrls);
       return;

--- a/src/transport/nostr-server/announcement-manager.ts
+++ b/src/transport/nostr-server/announcement-manager.ts
@@ -126,6 +126,7 @@ export class AnnouncementManager {
   private pricingTags: string[][];
   private readonly shouldPublishRelayList: boolean;
   private readonly relayListUrls?: string[];
+  private readonly hasExplicitBootstrapRelayUrls: boolean;
   private readonly bootstrapRelayUrls: readonly string[];
   private readonly onDispatchMessage: (message: JSONRPCMessage) => void;
   private readonly onPublishEvent: (event: NostrEvent) => Promise<void>;
@@ -157,6 +158,8 @@ export class AnnouncementManager {
     this.pricingTags = options.pricingTags ?? [];
     this.shouldPublishRelayList = options.publishRelayList ?? true;
     this.relayListUrls = options.relayListUrls;
+    this.hasExplicitBootstrapRelayUrls =
+      options.bootstrapRelayUrls !== undefined;
     this.bootstrapRelayUrls =
       options.bootstrapRelayUrls ?? DEFAULT_BOOTSTRAP_RELAY_URLS;
     this.onDispatchMessage = options.onDispatchMessage;
@@ -623,9 +626,19 @@ export class AnnouncementManager {
   }
 
   private getDiscoverabilityPublishRelayUrls(): string[] {
+    const advertisedRelayUrls = this.getAdvertisedRelayUrls();
+    const shouldSkipDefaultBootstrapRelayUrls =
+      !this.hasExplicitBootstrapRelayUrls &&
+      advertisedRelayUrls.length > 0 &&
+      advertisedRelayUrls.every((relayUrl) => this.isLocalRelayUrl(relayUrl));
+
+    const bootstrapRelayUrls = shouldSkipDefaultBootstrapRelayUrls
+      ? []
+      : this.bootstrapRelayUrls;
+
     return this.dedupeRelayUrls([
-      ...this.getAdvertisedRelayUrls(),
-      ...this.bootstrapRelayUrls,
+      ...advertisedRelayUrls,
+      ...bootstrapRelayUrls,
     ]);
   }
 
@@ -633,9 +646,45 @@ export class AnnouncementManager {
     return [...new Set(relayUrls.filter((relayUrl) => relayUrl.length > 0))];
   }
 
+  private isLocalRelayUrl(relayUrl: string): boolean {
+    if (relayUrl.startsWith('memory://')) {
+      return true;
+    }
+
+    let url: URL;
+    try {
+      url = new URL(relayUrl);
+    } catch {
+      return false;
+    }
+
+    const hostname = url.hostname.toLowerCase();
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      hostname === '0.0.0.0'
+    );
+  }
+
+  private isWebsocketRelayUrl(relayUrl: string): boolean {
+    let url: URL;
+    try {
+      url = new URL(relayUrl);
+    } catch {
+      return false;
+    }
+
+    return url.protocol === 'ws:' || url.protocol === 'wss:';
+  }
+
   private async publishDiscoverabilityEvent(event: NostrEvent): Promise<void> {
     const relayUrls = this.getDiscoverabilityPublishRelayUrls();
-    if (relayUrls.length && this.onPublishEventToRelays) {
+    if (
+      relayUrls.length &&
+      this.onPublishEventToRelays &&
+      relayUrls.every((relayUrl) => this.isWebsocketRelayUrl(relayUrl))
+    ) {
       await this.onPublishEventToRelays(event, relayUrls);
       return;
     }

--- a/src/transport/nostr-server/utils.ts
+++ b/src/transport/nostr-server/utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Returns true when the relay URL is local-only and should not trigger
+ * default public bootstrap publication by itself.
+ */
+export function isLocalRelayUrl(relayUrl: string): boolean {
+  if (relayUrl.startsWith('memory://')) {
+    return true;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(relayUrl);
+  } catch {
+    return false;
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '0.0.0.0'
+  );
+}
+
+/**
+ * Returns true when the relay URL uses a websocket transport.
+ */
+export function isWebsocketRelayUrl(relayUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(relayUrl);
+  } catch {
+    return false;
+  }
+
+  return url.protocol === 'ws:' || url.protocol === 'wss:';
+}


### PR DESCRIPTION
Addresses #49 

Discoverability publication could include default public bootstrap relays even when tests were intentionally scoped to local or memory relays.
That introduced external timing variance and occasional timeout failures in CI reruns.
In addition, one oversized-transfer e2e assertion counted all server-authored events, so discoverability metadata events could interfere with expected transport-response assertions.

**What Changed**
1. In src/transport/nostr-server/announcement-manager.ts, discoverability relay target selection is now deterministic:

- Default bootstrap relays are skipped when all operational relays are local or memory and bootstrap relays were not explicitly configured.
- Explicit bootstrap relay configuration is preserved.
- Relay-subset publication is used only when all targets are websocket URLs; otherwise it falls back to direct publish.
2. Added focused coverage in src/transport/nostr-server/announcement-manager.test.ts:

- Local relay setup does not append default bootstrap relays.
- Explicit bootstrap relays are still honored.
- Non-websocket targets use fallback publish behavior.
3. Tightened e2e assertion scope in src/transport/nostr-oversized-transfer.e2e.test.ts:

- Filter now restricts to transport response events, preventing metadata-event interference.
4. Added release note in .changeset/gentle-bats-listen.md.

**Validation**
1. Targeted suites passed:

- Announcement manager relay publication tests
- Oversized transfer e2e tests
2. Repeated stability run passed:

- 8 consecutive iterations of targeted suites
3. Integration and full-suite checks passed:

- Server transport tests
- Full SDK test suite (0 failures)
- Build and lint both pass