### PR TITLE
fix: add d tag to addressable events and verify relay list signatures

### DIFF
--- a/src/transport/nostr-client/server-relay-discovery.ts
+++ b/src/transport/nostr-client/server-relay-discovery.ts
@@ -1,4 +1,5 @@
 import type { NostrEvent } from 'nostr-tools';
+import { verifyEvent } from 'nostr-tools';
 import {
   DEFAULT_TIMEOUT_MS,
   NOSTR_TAGS,
@@ -102,6 +103,11 @@ export async function fetchServerRelayList(params: {
   )[0];
 
   if (!latestEvent) {
+    return [];
+  }
+
+  if (!verifyEvent(latestEvent)) {
+    console.warn('Relay list event signature verification failed, ignoring');
     return [];
   }
 

--- a/src/transport/nostr-server-transport.test.ts
+++ b/src/transport/nostr-server-transport.test.ts
@@ -302,7 +302,7 @@ describe.serial('NostrServerTransport', () => {
       });
 
       expect(relayListEvent.kind).toBe(RELAY_LIST_METADATA_KIND);
-      expect(relayListEvent.tags).toEqual([['r', relayUrl]]);
+      expect(relayListEvent.tags).toEqual([['d', ''], ['r', relayUrl]]);
 
       await server.close();
       await relayPool.disconnect();
@@ -341,7 +341,7 @@ describe.serial('NostrServerTransport', () => {
       });
 
       expect(relayListEvent.kind).toBe(RELAY_LIST_METADATA_KIND);
-      expect(relayListEvent.tags).toEqual([['r', relayUrl]]);
+      expect(relayListEvent.tags).toEqual([['d', ''], ['r', relayUrl]]);
 
       await expect(
         waitForNostrEvent({
@@ -495,7 +495,7 @@ describe.serial('NostrServerTransport', () => {
     });
 
     expect(bootstrapAnnouncement.kind).toBe(SERVER_ANNOUNCEMENT_KIND);
-    expect(bootstrapRelayList.tags).toEqual([['r', relayUrl]]);
+    expect(bootstrapRelayList.tags).toEqual([['d', ''], ['r', relayUrl]]);
 
     await server.close();
     await bootstrapPool.disconnect();

--- a/src/transport/nostr-server/announcement-manager.ts
+++ b/src/transport/nostr-server/announcement-manager.ts
@@ -218,7 +218,7 @@ export class AnnouncementManager {
       const eventTemplate = {
         kind: RELAY_LIST_METADATA_KIND,
         content: '',
-        tags: relayUrls.map((relayUrl) => [NOSTR_TAGS.RELAY, relayUrl]),
+        tags: [['d', ''], ...relayUrls.map((relayUrl) => [NOSTR_TAGS.RELAY, relayUrl])],
         created_at: Math.floor(Date.now() / 1000),
         pubkey: publicKey,
       };
@@ -576,7 +576,7 @@ export class AnnouncementManager {
           const eventTemplate = {
             kind: mapping.kind,
             content: JSON.stringify(result),
-            tags: mapping.tags,
+            tags: [['d', ''], ...mapping.tags],
             created_at: Math.floor(Date.now() / 1000),
             pubkey: recipientPubkey,
           };


### PR DESCRIPTION
Two small fixes found while i was exploring the SDK against the spec:

1. Kinds 11316-11320 and 10002 are addressable/replaceable events per NIP-01 and require a d tag for relay replacement to work. Without it relays accumulate stale duplicate announcements instead of replacing them. Added `["d", ""]` to both publishAnnouncementEvent and publishRelayList.

2. The kind 10002 relay list event fetched during CEP-17 discovery was trusted without signature verification. A malicious relay could serve a forged event pointing clients to attacker-controlled relays. Added verifyEvent check before extracting relay URLs.

