### PR TITLE
Fix stale timestamp in queued NWC requests  

### DIFF
--- a/.changeset/fix-nwc-stale-timestamp.md
+++ b/.changeset/fix-nwc-stale-timestamp.md
@@ -1,0 +1,5 @@
+---
+"@contextvm/sdk": patch
+---
+
+Fix stale timestamp in queued NWC requests by capturing `nowSeconds()` inside the `run()` closure so the `created_at` field reflects when the event is actually built and signed, not when it was enqueued.

--- a/src/payments/nip47/nwc-client.ts
+++ b/src/payments/nip47/nwc-client.ts
@@ -179,9 +179,8 @@ export class NwcClient {
     responseResultGuard?: (result: unknown) => result is R;
     expirationSeconds?: number;
   }): Promise<NwcResponse<M, R>> {
-    const now = nowSeconds();
-
     const run = async (): Promise<NwcResponse<M, R>> => {
+      const now = nowSeconds();
       await this.connect();
 
       const clientSecretKey = hexToBytes(this.connection.clientSecretKeyHex);


### PR DESCRIPTION
`nowSeconds()` was being called outside the `run()` closure in `NwcClient.request()`, so the timestamp got frozen at the moment the request was queued. Not when it actually executed. 

When the queue was backed up (slow wallet, previous request timing out), the event went out with a stale `created_at` and relays would reject it.

Moved now inside `run()` so it's captured right before the event is built and signed.

Fixes #56                                                                    