### PR TITLE
Clean up NWC relay subscriptions when a request times out

### DIFF
--- a/.changeset/fix-nwc-subscription-leak.md
+++ b/.changeset/fix-nwc-subscription-leak.md
@@ -1,0 +1,5 @@
+---
+"@contextvm/sdk": patch
+---
+
+Fix NWC relay subscriptions not being cleaned up when a request times out by moving the `.finally()` cleanup onto the `withTimeout()` promise instead of the inner promise, so the subscription is closed regardless of whether the timeout or the relay response wins the race.

--- a/src/payments/nip47/nwc-client.ts
+++ b/src/payments/nip47/nwc-client.ts
@@ -179,9 +179,8 @@ export class NwcClient {
     responseResultGuard?: (result: unknown) => result is R;
     expirationSeconds?: number;
   }): Promise<NwcResponse<M, R>> {
-    const now = nowSeconds();
-
     const run = async (): Promise<NwcResponse<M, R>> => {
+      const now = nowSeconds();
       await this.connect();
 
       const clientSecretKey = hexToBytes(this.connection.clientSecretKeyHex);

--- a/src/payments/nip47/nwc-client.ts
+++ b/src/payments/nip47/nwc-client.ts
@@ -108,13 +108,11 @@ export class NwcClient {
         });
     });
 
-    promise.finally(() => unsubscribe?.());
-
     return await withTimeout(
       promise,
       this.responseTimeoutMs,
       'NWC info event fetch timed out',
-    );
+    ).finally(() => unsubscribe?.());
   }
 
   public async subscribeNotifications(params: {
@@ -252,9 +250,6 @@ export class NwcClient {
           });
       });
 
-      // Also cleanup on timeout/error paths.
-      responsePromise.finally(() => unsubscribeResponse?.());
-
       this.logger.debug('publish request', {
         method: params.method,
         requestId: signedRequest.id,
@@ -281,7 +276,7 @@ export class NwcClient {
         responsePromise,
         this.responseTimeoutMs,
         `NWC response timed out for ${params.method}`,
-      );
+      ).finally(() => unsubscribeResponse?.());
 
       // Validate correlation.
       const eTag = getTagValue(responseEvent.tags as string[][], 'e');


### PR DESCRIPTION
Both `request()` and `fetchInfoNotificationTypes()` were attaching their subscription cleanup to the original inner promise via `.finally()`. 

The issue is `withTimeout()` races that promise against a timer. If the timer wins, the outer call rejects but the inner promise just hangs there unsettled, so `.finally()` never runs and the relay subscription never gets closed.

Moved `.finally()` onto the `withTimeout(...)` promise instead, so cleanup happens regardless of whether the timeout or the relay response wins the race.

Fixes #58