### PR TITLE
Close ping subscription on relay after each liveness check 

### DIFF
--- a/src/relay/applesauce-relay-pool.ts
+++ b/src/relay/applesauce-relay-pool.ts
@@ -635,6 +635,14 @@ export class ApplesauceRelayPool implements RelayHandler {
         logger.warn('Liveness check failed, triggering rebuild', { error });
       }
       this.rebuild('liveness-timeout');
+    } finally {
+      for (const relay of connectedRelays) {
+        try {
+          (relay as Relay).send(['CLOSE', pingId]);
+        } catch {
+          // best effort
+        }
+      }
     }
   }
 


### PR DESCRIPTION
`checkLiveness()` sends a `REQ` directly to each relay via `relay.send()` but never sends the corresponding `CLOSE`. The RxJS unsubscribe only tears down the local message listener. The server side subscription stays open. Over a long session this stacks up on every ping cycle.                                 

Added a finally block that sends `['CLOSE', pingId]` to each relay after the check completes, whether it succeeded or timed out.

Fixes #60 