### PR TITLE
Fix/relay pool ghost rebuild after disconnect

### DIFF
--- a/.changeset/late-probe-ghost-rebuild.md
+++ b/.changeset/late-probe-ghost-rebuild.md
@@ -1,0 +1,5 @@
+---
+'@contextvm/sdk': patch
+---
+
+Fix `ApplesauceRelayPool` resurrection after `disconnect()`: a liveness probe pending across terminal teardown could time out afterwards and run `rebuild()` on the dead pool, recreating `Relay` objects, observers, and an immortal ping-monitor interval (created after `destroy$.complete()`, so `takeUntil` never stops it). `rebuild()` now guards on the lifecycle `AbortController` signal that `disconnect()` aborts, so late probe timeouts are no-ops.

--- a/src/relay/applesauce-relay-pool.test.ts
+++ b/src/relay/applesauce-relay-pool.test.ts
@@ -1012,10 +1012,13 @@ describe('ApplesauceRelayPool terminal lifecycle', () => {
     const internals = pool as unknown as GhostPoolInternals;
 
     // Fake relay: reports connected, accepts sends, never answers EOSE, closeable.
+    let pingCount = 0;
     const fakeRelay = {
       url: 'wss://relay.example',
       connected: true,
-      send: () => {},
+      send: () => {
+        pingCount += 1;
+      },
       close: () => {},
       message$: new Subject<unknown>(),
       connected$: new Subject<boolean>(),
@@ -1033,6 +1036,8 @@ describe('ApplesauceRelayPool terminal lifecycle', () => {
 
     await sleep(25); // probe fires and goes pending (times out at +60ms)
     expect(internals.destroy$.isStopped).toBe(false);
+    // Guard against vacuous pass: the probe must actually be in flight across disconnect.
+    expect(pingCount).toBeGreaterThan(0);
 
     await pool.disconnect();
 

--- a/src/relay/applesauce-relay-pool.test.ts
+++ b/src/relay/applesauce-relay-pool.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { bytesToHex } from 'nostr-tools/utils';
 import { sleep } from 'bun';
+import { Subject } from 'rxjs';
 import {
   generateSecretKey,
   getPublicKey,
@@ -991,4 +992,57 @@ describe('ApplesauceRelayPool configuration', () => {
 
     pool.unsubscribe();
   });
+});
+
+describe('ApplesauceRelayPool terminal lifecycle', () => {
+  test('late liveness-probe timeout after disconnect() does not resurrect the pool', async () => {
+    type GhostPoolInternals = {
+      relays: unknown[];
+      relayObservers: unknown[];
+      subscriptions: Map<string, unknown>;
+      pingSubscription?: { closed: boolean };
+      startPingMonitor: () => void;
+      destroy$: Subject<void>;
+    };
+
+    const pool = new ApplesauceRelayPool(['wss://relay.example'], {
+      pingFrequencyMs: 10,
+      pingTimeoutMs: 60,
+    });
+    const internals = pool as unknown as GhostPoolInternals;
+
+    // Fake relay: reports connected, accepts sends, never answers EOSE, closeable.
+    const fakeRelay = {
+      url: 'wss://relay.example',
+      connected: true,
+      send: () => {},
+      close: () => {},
+      message$: new Subject<unknown>(),
+      connected$: new Subject<boolean>(),
+      error$: new Subject<unknown>(),
+    };
+    internals.relays = [fakeRelay] as never;
+
+    // Probe-shaped subscription entry + running monitor = pending liveness probe.
+    internals.subscriptions.set('probe', {
+      id: 'probe',
+      filters: [],
+      onEvent: () => {},
+    });
+    internals.startPingMonitor();
+
+    await sleep(25); // probe fires and goes pending (times out at +60ms)
+    expect(internals.destroy$.isStopped).toBe(false);
+
+    await pool.disconnect();
+
+    expect(internals.relays).toHaveLength(0); // fully torn down
+
+    await sleep(120); // late probe times out here, after terminal disconnect
+
+    expect(internals.destroy$.isStopped).toBe(true);
+    expect(internals.relays).toHaveLength(0); // must NOT resurrect
+    expect(internals.relayObservers).toHaveLength(0);
+    expect(internals.pingSubscription).toBeUndefined(); // no immortal monitor
+  }, 10_000);
 });

--- a/src/relay/applesauce-relay-pool.ts
+++ b/src/relay/applesauce-relay-pool.ts
@@ -622,7 +622,9 @@ export class ApplesauceRelayPool implements RelayHandler {
 
   /** Rebuilds the relay group and replays all subscriptions (single-flight) */
   private rebuild(reason: string): void {
-    if (this.rebuildInFlight) return;
+    // A pending liveness probe can time out after terminal disconnect(); the
+    // pool must never resurrect (same lifecycle signal publish() honors).
+    if (this.lifecycle.signal.aborted || this.rebuildInFlight) return;
 
     this.rebuildInFlight = (async () => {
       this.relayGeneration += 1;


### PR DESCRIPTION
`disconnect()` is terminal, but a liveness probe pending across it times out up to `pingTimeoutMs` later and runs `rebuild()` on the dead pool — recreating `Relay`s, observers, and restarting the ping monitor. That timer is immortal: it subscribes after `destroy$.complete()`, and `takeUntil` on an already-completed plain `Subject` never fires (verified on rxjs 7.8.2). Result: one dead object graph + one idle interval per disposal landing in a probe window (~20s of every 120s). No sockets reopen — resource-lifetime bug only.

**Fix**: `rebuild()` guards on the same `lifecycle.signal` that `disconnect()` aborts and `publish()` already honors. Covers all rebuild triggers. The optional abort-aware probe cancellation was skipped — with the guard, the late timeout throws into a no-op and self-clears.

**Test**: offline regression test (fake relay, real timers, no network) asserting no relays/observers/monitor exist after a post-disconnect probe timeout. Verified the rxjs `takeUntil`-on-completed-Subject semantics empirically; full relay suite 25/25, tsc + eslint clean.