### PR TITLE
fix(open-stream): ignore late keepalive publication rejection after matching pong

### DIFF
--- a/.changeset/open-stream-late-probe-reject.md
+++ b/.changeset/open-stream-late-probe-reject.md
@@ -1,0 +1,5 @@
+---
+'@contextvm/sdk': patch
+---
+
+Fix `OpenStreamSession` aborting an acknowledged stream when a keepalive ping's publication rejects late: if a matching pong already reconciled the probe (or a newer probe superseded it), the late publication error is now ignored. Streams with proven liveness survive relay acknowledgement failures that resolve after the pong; probes that are still unacknowledged abort exactly as before.

--- a/src/transport/open-stream/session.test.ts
+++ b/src/transport/open-stream/session.test.ts
@@ -925,4 +925,82 @@ describe('OpenStreamSession staleness', () => {
     session.dispose();
     await session.closed.catch(() => undefined);
   });
+
+  test('ignores late keepalive publication rejection after a matching pong', async () => {
+    let rejectPing: ((error: Error) => void) | undefined;
+    const session = new OpenStreamSession({
+      progressToken: 'token-late-reject-after-pong',
+      maxBufferedChunks: 8,
+      maxBufferedBytes: 1024,
+      idleTimeoutMs: 10,
+      probeTimeoutMs: 5_000, // backstop that must not fire in this scenario
+      closeGracePeriodMs: 100,
+      sendPing: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectPing = reject; // publication pends on relay acknowledgements
+        }),
+    });
+
+    await session.processFrame(1, {
+      type: 'open-stream',
+      frameType: 'start',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20)); // probe armed, publication pending
+
+    const pendingProbeNonce = (
+      session as unknown as { pendingProbeNonce?: string }
+    ).pendingProbeNonce;
+    expect(pendingProbeNonce).toBeTypeOf('string'); // probe in flight
+    // Hold this probe's rejecter: the pong refreshes the idle timer, so a
+    // second probe could overwrite the binding before we read it below.
+    const rejectProbe = rejectPing!;
+
+    await session.processFrame(2, {
+      type: 'open-stream',
+      frameType: 'pong',
+      nonce: pendingProbeNonce!,
+    });
+    expect(session.isActive).toBe(true); // probe acknowledged
+
+    rejectProbe(new Error('relay acknowledgement failed')); // late rejection
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(session.isActive).toBe(true); // acknowledged stream must survive
+
+    session.dispose();
+    await expect(session.closed).resolves.toBeUndefined();
+  });
+
+  test('still aborts when keepalive publication rejects while the probe is unacknowledged', async () => {
+    let rejectPing: ((error: Error) => void) | undefined;
+    const session = new OpenStreamSession({
+      progressToken: 'token-late-reject-no-pong',
+      maxBufferedChunks: 8,
+      maxBufferedBytes: 1024,
+      idleTimeoutMs: 10,
+      probeTimeoutMs: 5_000,
+      closeGracePeriodMs: 100,
+      sendPing: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectPing = reject;
+        }),
+    });
+    const closed = session.closed.catch((error: unknown) => error);
+
+    await session.processFrame(1, {
+      type: 'open-stream',
+      frameType: 'start',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20)); // probe armed, no pong
+
+    rejectPing!(new Error('relay acknowledgement failed'));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(session.isActive).toBe(false); // fast-path abort preserved
+    expect(await closed).toBeInstanceOf(Error);
+
+    session.dispose();
+  });
 });

--- a/src/transport/open-stream/session.ts
+++ b/src/transport/open-stream/session.ts
@@ -432,7 +432,11 @@ export class OpenStreamSession implements OpenStreamSessionLike<string> {
     try {
       await this.sendPing?.(nonce);
     } catch (error) {
-      if (!this.active) return; // probe timeout may have already finalized
+      // A matching pong already reconciled this probe (or a newer probe
+      // superseded it); a late publication rejection must not abort a stream
+      // with proven liveness. A truly undelivered ping still fails via the
+      // probe timeout armed before publishing.
+      if (!this.active || this.pendingProbeNonce !== nonce) return;
       await this.finishAborted(
         error instanceof Error ? error : new Error(String(error)),
         'Failed to send keepalive ping',


### PR DESCRIPTION
A pending keepalive publication could reject after its pong already reconciled the probe (relay acknowledgement accounting can resolve after the coordinator answered), aborting a stream whose liveness was proven. Mirror handleProbeTimeout's existing nonce guard: only abort when this probe is still unacknowledged. Truly undelivered pings still fail via the probe timeout, which is armed before publishing — no deadline weakened, no replay added.